### PR TITLE
Add Andri Lim from Nimbus/Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Reth | [Dragan Rakita](https://github.com/rakita/) | 1 | 
  | Status | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
  | Status | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |
+ | Status | [Andri Lim](https://github.com/jangko/) | 1 |
  | Status | [Dustin Brody](https://github.com/tersec/) | 1 |
  | Status | [Etan Kissling](https://github.com/etan-status/) | 1 |
  | Status | [Eugene Kabanov](https://github.com/cheatfate/) | 1 |


### PR DESCRIPTION
## Name

Andri Lim, aka [jangko](https://github.com/jangko).

## Team

Nimbus EL

## Short summary of their work / eligibility

Andri has been the most prolific contributor to the Nimbus execution layer client. For a long period of time, he was the sole engineer working on it. He poses an unparalleled breadth of knowledge regarding the protocol and he is frequently sought for advice by his team members. He hasn't joined the PG in the past for personal reasons, but he is looking forward to be a  member of PG V2.

## Link to some work

https://github.com/status-im/nimbus-eth1/graphs/contributors

## Start date of relevant projects

December 2018

## Proposed weight (full or partial)

Full
