### PR TITLE
Add Manu Napela from Prysm

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -182,6 +182,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Prysmatic | [Sammy Rosso](https://github.com/saolyn/) | 1 |
  | Prysmatic | [Taran Singh](https://github.com/Taranpreet26311/) | 0.5 |
  | Prysmatic | [Terence Tsao](https://github.com/terencechain/) | 1 |
+ | Prysmatic | [Manu Nalepa](https://github.com/nalepae) | 1 |
  | Reth | [Alexey Shekhirin](https://github.com/shekhirin/) | 1 |
  | Reth | [Dan Cline](https://github.com/rjected/) | 1 |
  | Reth | [Dragan Rakita](https://github.com/rakita/) | 1 |


### PR DESCRIPTION
# Add Manu from Prysm

- Name: Manu Nalepa / @nalepae
- Team: Prysm
- Start date of relevant projects: 
  - [EPF Third Cohort](https://github.com/eth-protocol-fellows/cohort-three): 2022-10-30 
  - [ETH Validator Watcher](https://github.com/kilnfi/eth-validator-watcher): 2023-05-30 
  - Prysm (Full time contributor): 2023-10-30
- Proposed weight: full
- Time off: 6 months*

_\*The time off of 6 months accounts for part-time weight in the 12 months prior to joining Offchain  Labs / Prysm team._


Short summary of their work / eligibility: 

Manu has been meaningfully contributing to Ethereum protocol development since October, 2022 when he joined the Ethereum Protocol Fellowship program with a project to rewrite Prysm's BN<>VC connection from gRPC to json using the standardized beacon API. Since then has contributed several works of note, including a validator watcher project to assist stakers with monitoring their validator deployments. In October 2023, Manu joined Offchain Labs as a full time contributor to Prysm.

Links to notable work:

- [EPF Project rewriting Prysm API](https://github.com/eth-protocol-fellows/cohort-three/blob/master/projects/prysm-beacon-api-compliant-validator.md)
- [List of commits on Prysm (EPF + Full time)](https://github.com/prysmaticlabs/prysm/commits?author=nalepae)
- [List of commits on ETH validator watcher (creator / main contributor)](https://github.com/kilnfi/eth-validator-watcher/commits?author=nalepae)
- [ETH validator watcher official talk during EthCC 6](https://www.youtube.com/watch?v=SkyncLrME1g&t=12s)
- [Ethereum anti-slashing strategies blog post](https://www.kiln.fi/post/ethereum-anti-slashing-strategies)
- [EPF day final project presentation](https://www.youtube.com/watch?v=oF_BRlXMVNY&t=2314s)
- [Panel moderation "Burn the MEV' with Justin Drake / Uri Klarman and Stéphane Gosselin.](https://www.youtube.com/watch?v=ssGsRUmAZvU)
- [EIP repo commits](https://github.com/ethereum/EIPs/commits?author=nalepae)
- [Lighthouse repo commits](https://github.com/sigp/lighthouse/commits?author=nalepae)

