### PR TITLE
Add Matthias Seitz

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -185,6 +185,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Reth | [Alexey Shekhirin](https://github.com/shekhirin/) | 1 |
  | Reth | [Dan Cline](https://github.com/rjected/) | 1 |
  | Reth | [Dragan Rakita](https://github.com/rakita/) | 1 |
+ | Reth | [Matthias Seitz](https://github.com/mattsse/) | 1 |
  | Status | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
  | Status | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |
  | Status | [Dustin Brody](https://github.com/tersec/) | 1 |


### PR DESCRIPTION
- Name: Matthias Seitz
- Github: [@mattsse](https://github.com/mattsse)
- Team: Reth
- Start date of relevant projects:
- October 2022 - Now
- Proposed weight: Full (1.0)
- Short summary of their work/eligibility:
  - Designed and implemented reth’s p2p
  - Designed and implemented reth's txpool and EIP-4844 support
  - Added reth's implementation of the engine API
  - Implemented reth's RPC and tracing support
- Commits:
  - https://github.com/paradigmxyz/reth/commits?author=mattsse
  - https://github.com/ralexstokes/mev-rs/commits?author=mattsse