### PR TITLE
members(reth): Add Roman Krasiuk

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -186,6 +186,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Reth | [Dan Cline](https://github.com/rjected/) | 1 |
  | Reth | [Dragan Rakita](https://github.com/rakita/) | 1 |
  | Reth | [Emilia Hane](https://github.com/emhane) | 1 |
+ | Reth | [Roman Krasiuk](https://github.com/rkrasiuk) | 1 |
  | Reth | [joshie](https://github.com/joshieDo) | 1 |
  | Status | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
  | Status | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |


### PR DESCRIPTION
- Name: Roman Krasiuk
- Github: [@rkrasiuk](https://github.com/rkrasiuk)
- Team: Reth
- Start date of relevant projects:
  * October 2022 - Now
- Proposed weight: Full (1.0)
- Short summary of their work/eligibility:
  * Implemented reth's merkle trie
  * Implemented reth's beacon consensus engine
  * Contributed to reth's historical sync
- Commits:
  * https://github.com/paradigmxyz/reth/commits?author=rkrasiuk