### PR TITLE
Add Piotr Dobaczewski (EF Ipsilon)

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -54,6 +54,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
  | EF Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |
  | EF Ipsilon | [Radosław Zagórowicz](https://github.com/rodiazet) | 1 |
+ | EF Ipsilon | [Piotr Dobaczewski](https://github.com/pdobacz) | 1 |
  | EF JavaScript | [Amir Ghorbanian](https://github.com/scorbajio/) | 1 |
  | EF JavaScript | [Andrew Day](https://github.com/acolytec3/) | 1 |
  | EF JavaScript | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |


### PR DESCRIPTION
- Name: Piotr Dobaczewski
- Team: EF Ipsilon
- Work link:
   - evmone: https://github.com/ethereum/evmone/commits?author=pdobacz
   - EOF: https://github.com/ipsilon/eof/commits?author=pdobacz
- Short summary of their work / eligibility: Piotr is full-time member of Ipsilon. Since his start in September 2023 we has been working on EOF spec and implementation.
- start date of relevant projects: September 2023
- proposed weight: full (1.0)