### PR TITLE
Add pk910 from EF DevOps

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -40,6 +40,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EF DevOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |
  | EF DevOps | [Barnabas Busa](https://github.com/barnabasbusa/) | 1 |
  | EF DevOps | [Andrew Davis](https://github.com/savid/) | 1 |
+ | EF DevOps | [pk910](https://github.com/pk910/) | 1 |
  | EF Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
  | EF Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
  | EF Geth | [Felix Lange](https://github.com/fjl/) | 1 |


### PR DESCRIPTION
## Add pk910 from EF Devops

* Name: pk910 / @pk910
* Team/Project: EF DevOps - [ethPandaOps](https://github.com/ethpandaops)
* Link to relevant work
https://github.com/pk910/dora
https://github.com/ethpandaops/assertoor
https://github.com/ethpandaops/dugtrio
https://github.com/pk910/PoWFaucet
https://github.com/ephemery-testnet/ephemery-resources
* Summary of their work / eligibility:

pk910 started with the ethPandaOps team in September 2023. However, even before this date, pk has been a very active contributor towards different Ethereum projects - **powfaucet** and **ephemery** just to name a few. 
Since he has started, he has been working on various toolings such as **Dora** - which enables us to have a great (lightweight) overview on different devnets and testnets or **assertoor** - that provides a robust and versatile tool designed for comprehensive testing of various Ethereum networks. 
He has made various improvements other improvements towards [ethereum-helm-charts](https://github.com/ethpandaops/ethereum-helm-charts) and Kurtosis [ethereum-package](https://github.com/kurtosis-tech/ethereum-package) as well. 

pk910 has been working full time with us so I would like to propose him to be added to the Protocol Guild with a weight of 1.