### PR TITLE
Proposing Matt Nelson for partial-weight membership.

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -132,6 +132,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Hyperledger Besu | [Gabriel Trintinalia](https://github.com/Gabriel-Trintinalia/) | 1 |
  | Hyperledger Besu | [Jason Frame](https://github.com/jframe/) | 1 |
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
+ | Hyperledger Besu | [Matt Nelson](https://github.com/non-fungible-nelson) | 0.5 |
  | Hyperledger Besu | [pinges](https://github.com/pinges/) | 1 |
  | Hyperledger Besu | [Sally Macfarlane](https://github.com/macfarla/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |


### PR DESCRIPTION
Matt Nelson has been handling product management for Besu for the last 2+ years as  Product Manager for Mainnet contributors to Hyperledger Besu. In this role, he has been working on Besu since before the Merge to:

- schedule working priorities
- determine R&D focus areas 
- devise product differentiation
- coordinate and planning Besu releases
- handle team administration to free up engineering overhead. 
 
Matt coordinates Besu opinions and voices them for All Core Devs, which requires him to cat-herd Consensys teams like MetaMask and Infura, to gather their input. He provides direct user support for Besu users, stakers, and more. He works with various news publications via Consensys and Hyperledger PR to provide educational content around protocol upgrades, Ethereum R&D topics, and more (For example he heavily supported Merge PR campaigns across the industry). Matt also directly [contributes to Besu documentation](https://github.com/hyperledger/besu-docs/commits?author=non-fungible-nelson) via PRs and make PRs to the Besu code-base to improve UX.

Matt also does management of Web3Signer and its specifications, which have crossed over into the Ethereum protocol via the [Remote Signing API](https://github.com/ethereum/remote-signing-api).