### PR TITLE
Add Echo from EF ARG

### DIFF
--- a/docs/9-membership.md
+++ b/docs/9-membership.md
@@ -85,6 +85,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EF Research | [Dankrad Feist](https://github.com/dankrad/) | 1 |
  | EF Research | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
  | EF Research | [Domothy](https://github.com/domothyb/) | 1 |
+ | EF Research | [Echo](https://github.com/echoalice/) | 1 |
  | EF Research | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 |
  | EF Research | [George Kadianakis](https://github.com/asn-d6/) | 1 |
  | EF Research | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |


### PR DESCRIPTION
Name / identifier: [Echo](https://github.com/echoalice/)
Team: EF ARG
Start date of relevant projects: 04/01/2023
Proposed weight: Full (1.0)

## Short summary of their work / eligibility

Echo began his Ethereum contributions via an EF grant to work on scaling R&D, where he built out a [distributed hash table](https://github.com/EchoAlice/my_kademlia) and did some research into sybil-resistant DHTs. Written in Rust, this repository serves as an educational tool for those interested in understanding networking protocols necessary to achieve the high-scale of throughput necessary for the data scaling roadmap ("danksharding").

Echo was then hired full-time by the Ethereum Foundation in October following the successful grant to join the Applied Research Group.  He has been an active participant within PeerDAS research and design discussions and has contributed to some of Alex Stokes' repositories, including `ethereum-consensus` and `mev-rs` which aim to lower the barriers to entry for developers to enter these parts of the space with approachable toolkits. He has also been doing some prototyping work in the Lighthouse client to assist with their PeerDAS work and explored Dencun client performance at various blob gas limits.

## Links to some work

- [Distributed Hash Table](https://github.com/EchoAlice/my_kademlia)
- [Blob Archiver](https://github.com/EchoAlice/blob-archiver)
- [ethereum-consensus](https://github.com/EchoAlice/ethereum-consensus)
- [mev-rs](https://github.com/EchoAlice/mev-rs)