### PR TITLE
Erigon: change Michelangelo Riccobene's weight to 1

### DIFF
--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -118,7 +118,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Erigon | [Giulio Rebuffo](https://github.com/Giulio2002/) | 1 |
  | Erigon | [lupin012](https://github.com/lupin012/) | 0.5 |
  | Erigon | [Kairat Abylkasymov](https://github.com/racytech/) | 1 |
- | Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |
+ | Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 |
  | Erigon | [Somnath Banerjee](https://github.com/somnathb1/) | 1 |
  | Erigon | [Tullio Canepa](https://github.com/canepat/) | 1 |
  | Ethereum Cat Herders | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 |


### PR DESCRIPTION
Michelangelo Riccobene is now working full-time in Erigon, leading the newborn QA team specifically focused in improving Erigon stability and reliability.