### PR TITLE
feat(membership): add DaniPopes from Reth

### DIFF
--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -186,11 +186,12 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Prysmatic | [Manu Nalepa](https://github.com/nalepae) | 1 |
  | Reth | [Alexey Shekhirin](https://github.com/shekhirin/) | 1 |
  | Reth | [Dan Cline](https://github.com/rjected/) | 1 |
+ | Reth | [DaniPopes](https://github.com/DaniPopes) | 1 |
  | Reth | [Dragan Rakita](https://github.com/rakita/) | 1 |
- | Reth | [Matthias Seitz](https://github.com/mattsse/) | 1 |
  | Reth | [Emilia Hane](https://github.com/emhane) | 1 |
- | Reth | [Roman Krasiuk](https://github.com/rkrasiuk) | 1 |
  | Reth | [joshie](https://github.com/joshieDo) | 1 |
+ | Reth | [Matthias Seitz](https://github.com/mattsse/) | 1 |
+ | Reth | [Roman Krasiuk](https://github.com/rkrasiuk) | 1 |
  | Status | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
  | Status | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |
  | Status | [Dustin Brody](https://github.com/tersec/) | 1 |


### PR DESCRIPTION
- Name, GitHub: @DaniPopes
- Team: Reth
- Short summary of their work / eligibility:
  - Full time Rust developer at [Reth]
  - Worked with @rakita on improving the [Revm](https://github.com/bluealloy/revm) EVM implementation and performance
    - [Implemented EIP-4844](https://github.com/bluealloy/revm/pull/668)
    - [Commits](https://github.com/bluealloy/revm/commits/main/?author=DaniPopes)
  - Currently working on improving [Reth] historical sync performance
    - [Commits](https://github.com/paradigmxyz/reth/commits/main/?author=DaniPopes)
- Start date of relevant projects: August 2023
- Proposed weight: Full (1.0)

[Reth]: https://github.com/paradigmxyz/reth

---

I also sorted the list of Reth team member names