### PR TITLE
Add Andri Lim

### DIFF
--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -191,6 +191,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Reth | [Emilia Hane](https://github.com/emhane) | 1 |
  | Reth | [Roman Krasiuk](https://github.com/rkrasiuk) | 1 |
  | Reth | [joshie](https://github.com/joshieDo) | 1 |
+ | Status | [Andri Lim](https://github.com/jangko/) | 1 |
  | Status | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
  | Status | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |
  | Status | [Dustin Brody](https://github.com/tersec/) | 1 |


### PR DESCRIPTION
## Name
 
Andri Lim, aka [jangko](https://github.com/jangko).
## Team
 
Nimbus EL
## Short summary of their work / eligibility

Andri has been the most prolific contributor to the Nimbus execution layer client. For a long period of time, he was the sole engineer working on it. He poses an unparalleled breadth of knowledge regarding the protocol and he is frequently sought for advice by his team members. He hasn't joined the PG in the past for personal reasons, but he is looking forward to be a member of PG V2.
## Link to some work

https://github.com/status-im/nimbus-eth1/graphs/contributors
## Start date of relevant projects
 
December 2018
## Proposed weight (full or partial)
 
Full

(Based on https://github.com/protocolguild/documentation/pull/138 and depends on https://github.com/protocolguild/documentation/pull/160)