### PR TITLE
Update project/team names

### DIFF
--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -68,18 +68,18 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EthereumJS | [Jochem](https://github.com/jochem-brouwer/) | 1 |
  | EthereumJS | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
  | Portal Network (EF) | [Jason Carver](https://github.com/carver/) | 1 |
- | ortal Network (EF) | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
- | ortal Network (EF) | [Mike Ferris](https://github.com/mrferris/) | 1 |
- | ortal Network (EF) | [Ognyan Genev](https://github.com/ogenev/) | 1 |
- | ortal Network (EF) | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
- | ortal Network (EF) | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
- | Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
- | Protocol Support | [Guru](https://github.com/gurukamath/) | 1 |
- | Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
- | Protocol Support | [Peter Davies](https://github.com/ultratwo/) | 1 |
- | Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
- | Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
- | Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
+ | Portal Network (EF) | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
+ | Portal Network (EF) | [Mike Ferris](https://github.com/mrferris/) | 1 |
+ | Portal Network (EF) | [Ognyan Genev](https://github.com/ogenev/) | 1 |
+ | Portal Network (EF) | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
+ | Portal Network (EF) | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
+ | Protocol Support (EF) | [Danny Ryan](https://github.com/djrtwo/) | 1 |
+ | Protocol Support (EF)| [Guru](https://github.com/gurukamath/) | 1 |
+ | Protocol Support (EF)| [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
+ | Protocol Support (EF)| [Peter Davies](https://github.com/ultratwo/) | 1 |
+ | Protocol Support (EF)| [Sam Wilson](https://github.com/SamWilsn/) | 1 |
+ | Protocol Support (EF)| [Tim Beiko](https://github.com/timbeiko/) | 1 |
+ | Protocol Support (EF)| [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
  | Cryptography (EF) | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 |
  | Cryptography (EF) | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
  | Cryptography (EF) | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |

--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -67,12 +67,12 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EthereumJS | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |
  | EthereumJS | [Jochem](https://github.com/jochem-brouwer/) | 1 |
  | EthereumJS | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
- | Portal Network | [Jason Carver](https://github.com/carver/) | 1 |
- | Portal Network | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
- | Portal Network | [Mike Ferris](https://github.com/mrferris/) | 1 |
- | Portal Network | [Ognyan Genev](https://github.com/ogenev/) | 1 |
- | Portal Network | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
- | Portal Network | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
+ | EF Portal Network | [Jason Carver](https://github.com/carver/) | 1 |
+ | EF Portal Network | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
+ | EF Portal Network | [Mike Ferris](https://github.com/mrferris/) | 1 |
+ | EF Portal Network | [Ognyan Genev](https://github.com/ogenev/) | 1 |
+ | EF Portal Network | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
+ | EF Portal Network | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
  | Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
  | Protocol Support | [Guru](https://github.com/gurukamath/) | 1 |
  | Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
@@ -102,11 +102,11 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Robust Incentives Group (RIG) | [Davide Crapis](https://github.com/dcrapis/) | 1 |
  | Robust Incentives Group (RIG) | [Thomas Thiery](https://github.com/soispoke) | 1 |
  | Robust Incentives Group (RIG) | [Julian Ma](https://github.com/Ma-Julian) | 1 |
- | EF Security | [David Theodore](https://github.com/infosecual/) | 1 |
- | EF Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
- | EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
- | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
- | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
+ | EF Protocol Security | [David Theodore](https://github.com/infosecual/) | 1 |
+ | EF Protocol Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
+ | EF Protocol Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
+ | EF Protocol Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
+ | EF Protocol Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
  | Stateless Consensus | [Ignacio Hagopian](https://github.com/jsign/) | 1 |
  | Stateless Consensus | [Josh Rudolf](https://github.com/jrudolf/) | 1 |
  | EF Testing | [danceratopz](https://github.com/danceratopz) | 1 |

--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -35,51 +35,51 @@ If someone is doing work you feel should be eligible but is not currently listed
 
 | Team  |                Name / Link to work |  Multiplier |
 | :---        |        :--- |        :--- |
-| EF ARG | [Alex Stokes](https://github.com/ralexstokes/) | 1 |
- | EF ARG | [Echo](https://github.com/echoalice/) | 1 |
-| EF ARG | [Jacob Kaufmann](https://github.com/jacobkaufmann/) | 1 |
-| EF ARG | [Mike Neuder](https://github.com/michaelneuder) | 1 |
-| EF ARG | [Toni Wahrstätter](https://github.com/nerolation) | 1 |
-| EF DevOps | [Parithosh Jayanthi](https://github.com/parithosh/) | 1 |
- | EF DevOps | [Rafael Matias](https://github.com/skylenet/) | 0.5 |
- | EF DevOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |
- | EF DevOps | [Barnabas Busa](https://github.com/barnabasbusa/) | 1 |
- | EF DevOps | [Andrew Davis](https://github.com/savid/) | 1 |
- | EF DevOps | [pk910](https://github.com/pk910/) | 1 |
- | EF Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
- | EF Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
- | EF Geth | [Felix Lange](https://github.com/fjl/) | 1 |
- | EF Geth | [Jared Wasinger](https://github.com/jwasinger/) | 1 |
- | EF Geth | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 |
- | EF Geth | [Martin Holst Swende](https://github.com/holiman/) | 1 |
- | EF Geth | [Matt Garnett](https://github.com/lightclient/) | 1 |
- | EF Geth | [Peter Szilagyi](https://github.com/karalabe/) | 1 |
- | EF Geth | [Sina Mahmoodi](https://github.com/s1na/) | 1 |
- | EF Ipsilon | [Alex Beregszaszi](https://github.com/axic/) | 1 |
- | EF Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
- | EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
- | EF Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |
- | EF Ipsilon | [Radosław Zagórowicz](https://github.com/rodiazet) | 1 |
- | EF Ipsilon | [Piotr Dobaczewski](https://github.com/pdobacz) | 1 |
- | EF JavaScript | [Amir Ghorbanian](https://github.com/scorbajio/) | 1 |
- | EF JavaScript | [Andrew Day](https://github.com/acolytec3/) | 1 |
- | EF JavaScript | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |
- | EF JavaScript | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |
- | EF JavaScript | [Jochem](https://github.com/jochem-brouwer/) | 1 |
- | EF JavaScript | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
- | EF Portal | [Jason Carver](https://github.com/carver/) | 1 |
- | EF Portal | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
- | EF Portal | [Mike Ferris](https://github.com/mrferris/) | 1 |
- | EF Portal | [Ognyan Genev](https://github.com/ogenev/) | 1 |
- | EF Portal | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
- | EF Portal | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
- | EF Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
- | EF Protocol Support | [Guru](https://github.com/gurukamath/) | 1 |
- | EF Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
- | EF Protocol Support | [Peter Davies](https://github.com/ultratwo/) | 1 |
- | EF Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
- | EF Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
- | EF Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
+| Applied Research Group (ARG) | [Alex Stokes](https://github.com/ralexstokes/) | 1 |
+ | Applied Research Group (ARG) | [Echo](https://github.com/echoalice/) | 1 |
+| Applied Research Group (ARG) | [Jacob Kaufmann](https://github.com/jacobkaufmann/) | 1 |
+| Applied Research Group (ARG) | [Mike Neuder](https://github.com/michaelneuder) | 1 |
+| Applied Research Group (ARG) | [Toni Wahrstätter](https://github.com/nerolation) | 1 |
+| ethPandaOps | [Parithosh Jayanthi](https://github.com/parithosh/) | 1 |
+ | ethPandaOps | [Rafael Matias](https://github.com/skylenet/) | 0.5 |
+ | ethPandaOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |
+ | ethPandaOps | [Barnabas Busa](https://github.com/barnabasbusa/) | 1 |
+ | ethPandaOps | [Andrew Davis](https://github.com/savid/) | 1 |
+ | ethPandaOps | [pk910](https://github.com/pk910/) | 1 |
+ | Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
+ | Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
+ | Geth | [Felix Lange](https://github.com/fjl/) | 1 |
+ | Geth | [Jared Wasinger](https://github.com/jwasinger/) | 1 |
+ | Geth | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 |
+ | Geth | [Martin Holst Swende](https://github.com/holiman/) | 1 |
+ | Geth | [Matt Garnett](https://github.com/lightclient/) | 1 |
+ | Geth | [Peter Szilagyi](https://github.com/karalabe/) | 1 |
+ | Geth | [Sina Mahmoodi](https://github.com/s1na/) | 1 |
+ | Ipsilon | [Alex Beregszaszi](https://github.com/axic/) | 1 |
+ | Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
+ | Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
+ | Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |
+ | Ipsilon | [Radosław Zagórowicz](https://github.com/rodiazet) | 1 |
+ | Ipsilon | [Piotr Dobaczewski](https://github.com/pdobacz) | 1 |
+ | EthereumJS | [Amir Ghorbanian](https://github.com/scorbajio/) | 1 |
+ | EthereumJS | [Andrew Day](https://github.com/acolytec3/) | 1 |
+ | EthereumJS | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |
+ | EthereumJS | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |
+ | EthereumJS | [Jochem](https://github.com/jochem-brouwer/) | 1 |
+ | EthereumJS | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
+ | Portal Network | [Jason Carver](https://github.com/carver/) | 1 |
+ | Portal Network | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
+ | Portal Network | [Mike Ferris](https://github.com/mrferris/) | 1 |
+ | Portal Network | [Ognyan Genev](https://github.com/ogenev/) | 1 |
+ | Portal Network | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
+ | Portal Network | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
+ | Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
+ | Protocol Support | [Guru](https://github.com/gurukamath/) | 1 |
+ | Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
+ | Protocol Support | [Peter Davies](https://github.com/ultratwo/) | 1 |
+ | Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
+ | Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
+ | Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
  | EF Cryptography | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 |
  | EF Cryptography | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
  | EF Cryptography | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
@@ -96,19 +96,19 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EF Research | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 |
  | EF Research | [Luca Zanolini](https://github.com/luca-zanolini) | 1 |
  | EF Research | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
- | EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
- | EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
- | EF Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
- | EF Robust Incentives Group (RIG) | [Davide Crapis](https://github.com/dcrapis/) | 1 |
- | EF Robust Incentives Group (RIG) | [Thomas Thiery](https://github.com/soispoke) | 1 |
- | EF Robust Incentives Group (RIG) | [Julian Ma](https://github.com/Ma-Julian) | 1 |
+ | Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
+ | Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
+ | Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
+ | Robust Incentives Group (RIG) | [Davide Crapis](https://github.com/dcrapis/) | 1 |
+ | Robust Incentives Group (RIG) | [Thomas Thiery](https://github.com/soispoke) | 1 |
+ | Robust Incentives Group (RIG) | [Julian Ma](https://github.com/Ma-Julian) | 1 |
  | EF Security | [David Theodore](https://github.com/infosecual/) | 1 |
  | EF Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
  | EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
- | EF Stateless Consensus| [Ignacio Hagopian](https://github.com/jsign/) | 1 |
- | EF Stateless Consensus| [Josh Rudolf](https://github.com/jrudolf/) | 1 |
+ | Stateless Consensus | [Ignacio Hagopian](https://github.com/jsign/) | 1 |
+ | Stateless Consensus | [Josh Rudolf](https://github.com/jrudolf/) | 1 |
  | EF Testing | [danceratopz](https://github.com/danceratopz) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |
@@ -173,17 +173,17 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Nethermind | [Tanishq Jasoria](https://github.com/tanishqjasoria/) | 1 |
  | Nethermind | [Tomasz Stanczak](https://github.com/tkstanczak/) | 0.5 |
  | Offchain Labs / Independent | [Aditya Asgaonkar](https://github.com/adiasg/) | 0.5 |
- | Prysmatic | [James He](https://github.com/james-prysm/) | 1 |
- | Prysmatic | [Kasey Kirkham](https://github.com/kasey/) | 1 |
- | Prysmatic | [Nishant Das](https://github.com/nisdas/) | 1 |
- | Prysmatic | [potuz](https://github.com/potuz/) | 1 |
- | Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
- | Prysmatic | [Radosław Kapka](https://github.com/rkapka/) | 1 |
- | Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 0.5 |
- | Prysmatic | [Sammy Rosso](https://github.com/saolyn/) | 1 |
- | Prysmatic | [Taran Singh](https://github.com/Taranpreet26311/) | 0.5 |
- | Prysmatic | [Terence Tsao](https://github.com/terencechain/) | 1 |
- | Prysmatic | [Manu Nalepa](https://github.com/nalepae) | 1 |
+ | Prysm | [James He](https://github.com/james-prysm/) | 1 |
+ | Prysm | [Kasey Kirkham](https://github.com/kasey/) | 1 |
+ | Prysm | [Nishant Das](https://github.com/nisdas/) | 1 |
+ | Prysm | [potuz](https://github.com/potuz/) | 1 |
+ | Prysm | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
+ | Prysm | [Radosław Kapka](https://github.com/rkapka/) | 1 |
+ | Prysm | [Raul Jordan](https://github.com/rauljordan/) | 0.5 |
+ | Prysm | [Sammy Rosso](https://github.com/saolyn/) | 1 |
+ | Prysm | [Taran Singh](https://github.com/Taranpreet26311/) | 0.5 |
+ | Prysm | [Terence Tsao](https://github.com/terencechain/) | 1 |
+ | Prysm | [Manu Nalepa](https://github.com/nalepae) | 1 |
  | Reth | [Alexey Shekhirin](https://github.com/shekhirin/) | 1 |
  | Reth | [Dan Cline](https://github.com/rjected/) | 1 |
  | Reth | [DaniPopes](https://github.com/DaniPopes) | 1 |
@@ -192,16 +192,16 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Reth | [joshie](https://github.com/joshieDo) | 1 |
  | Reth | [Matthias Seitz](https://github.com/mattsse/) | 1 |
  | Reth | [Roman Krasiuk](https://github.com/rkrasiuk) | 1 |
- | Status | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
- | Status | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |
- | Status | [Dustin Brody](https://github.com/tersec/) | 1 |
- | Status | [Etan Kissling](https://github.com/etan-status/) | 1 |
- | Status | [Eugene Kabanov](https://github.com/cheatfate/) | 1 |
- | Status | [Jacek Sieka](https://github.com/arnetheduck/) | 1 |
- | Status | [Jordan Hrycaj](https://github.com/mjfh/) | 1 |
- | Status | [Kim De Mey](https://github.com/kdeme/) | 1 |
- | Status | [Leonardo Bautista-Gomez](https://github.com/leobago/) | 0.5 |
- | Status | [Zahary Karadzhov](https://github.com/zah/) | 1 |
+ | Codex DAS | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 |
+ | Codex DAS | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 |
+| Codex DAS | [Leonardo Bautista-Gomez](https://github.com/leobago/) | 0.5 |
+ | Nimbus | [Dustin Brody](https://github.com/tersec/) | 1 |
+ | Nimbus | [Etan Kissling](https://github.com/etan-status/) | 1 |
+ | Nimbus | [Eugene Kabanov](https://github.com/cheatfate/) | 1 |
+ | Nimbus | [Jacek Sieka](https://github.com/arnetheduck/) | 1 |
+ | Nimbus | [Jordan Hrycaj](https://github.com/mjfh/) | 1 |
+ | Nimbus | [Kim De Mey](https://github.com/kdeme/) | 1 |
+ | Nimbus | [Zahary Karadzhov](https://github.com/zah/) | 1 |
  | Teku | [Courtney Hunter](https://github.com/courtneyeh/) | 1 |
  | Teku | [Dmitry Shmatko](https://github.com/zilm13/) | 1 |
  | Teku | [Enrico Del Fante](https://github.com/tbenr/) | 1 |

--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -85,17 +85,17 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EF Cryptography | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
  | EF Cryptography | [Mary Maller](https://github.com/mmaller) | 0.5 |
  | EF Cryptography | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
- | EF Research | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 |
- | EF Research | [Antonio Sanso](https://github.com/asanso/) | 1 |
- | EF Research | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 |
- | EF Research | [Dankrad Feist](https://github.com/dankrad/) | 1 |
- | EF Research | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 |
- | EF Research | [George Kadianakis](https://github.com/asn-d6/) | 1 |
- | EF Research | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |
- | EF Research | [Justin Drake](https://github.com/justindrake/) | 1 |
- | EF Research | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 |
- | EF Research | [Luca Zanolini](https://github.com/luca-zanolini) | 1 |
- | EF Research | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
+ | EF Consensus R&D | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 |
+ | EF Consensus R&D | [Antonio Sanso](https://github.com/asanso/) | 1 |
+ | EF Consensus R&D | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 |
+ | EF Consensus R&D | [Dankrad Feist](https://github.com/dankrad/) | 1 |
+ | EF Consensus R&D | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 |
+ | EF Consensus R&D | [George Kadianakis](https://github.com/asn-d6/) | 1 |
+ | EF Consensus R&D | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |
+ | EF Consensus R&D | [Justin Drake](https://github.com/justindrake/) | 1 |
+ | EF Consensus R&D | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 |
+ | EF Consensus R&D | [Luca Zanolini](https://github.com/luca-zanolini) | 1 |
+ | EF Consensus R&D | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
  | Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
  | Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
  | Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
@@ -137,6 +137,7 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
  | Independent | [Cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
+ | Independent | [Aditya Asgaonkar](https://github.com/adiasg/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
  | Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
  | Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |
@@ -172,7 +173,6 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Nethermind | [Ruben Buniatyan](https://github.com/rubo/) | 0.5 |
  | Nethermind | [Tanishq Jasoria](https://github.com/tanishqjasoria/) | 1 |
  | Nethermind | [Tomasz Stanczak](https://github.com/tkstanczak/) | 0.5 |
- | Offchain Labs / Independent | [Aditya Asgaonkar](https://github.com/adiasg/) | 0.5 |
  | Prysm | [James He](https://github.com/james-prysm/) | 1 |
  | Prysm | [Kasey Kirkham](https://github.com/kasey/) | 1 |
  | Prysm | [Nishant Das](https://github.com/nisdas/) | 1 |
@@ -213,8 +213,8 @@ If someone is doing work you feel should be eligible but is not currently listed
  | TXRX | [Alex Vlasov](https://github.com/ericsson49/) | 1 |
  | TXRX | [Anton Nashatyrev](https://github.com/Nashatyrev/) | 1 |
  | TXRX | [Mikhail Kalinin](https://github.com/mkalinin/) | 1 |
- | ConsenSys DDS | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 |
- | ConsenSys DDS | [Chenyi Zhang](https://github.com/czhang-fm/) | 0.5 |
+ | Dependable Distributed Systems (DDS) | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 |
+ | Dependable Distributed Systems (DDS) | [Chenyi Zhang](https://github.com/czhang-fm/) | 0.5 |
 
 ## Addresses and Weights
 

--- a/docs/09-membership.md
+++ b/docs/09-membership.md
@@ -67,12 +67,12 @@ If someone is doing work you feel should be eligible but is not currently listed
  | EthereumJS | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |
  | EthereumJS | [Jochem](https://github.com/jochem-brouwer/) | 1 |
  | EthereumJS | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
- | EF Portal Network | [Jason Carver](https://github.com/carver/) | 1 |
- | EF Portal Network | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
- | EF Portal Network | [Mike Ferris](https://github.com/mrferris/) | 1 |
- | EF Portal Network | [Ognyan Genev](https://github.com/ogenev/) | 1 |
- | EF Portal Network | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
- | EF Portal Network | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
+ | Portal Network (EF) | [Jason Carver](https://github.com/carver/) | 1 |
+ | ortal Network (EF) | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 |
+ | ortal Network (EF) | [Mike Ferris](https://github.com/mrferris/) | 1 |
+ | ortal Network (EF) | [Ognyan Genev](https://github.com/ogenev/) | 1 |
+ | ortal Network (EF) | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
+ | ortal Network (EF) | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
  | Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
  | Protocol Support | [Guru](https://github.com/gurukamath/) | 1 |
  | Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
@@ -80,38 +80,38 @@ If someone is doing work you feel should be eligible but is not currently listed
  | Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
  | Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
  | Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
- | EF Cryptography | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 |
- | EF Cryptography | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
- | EF Cryptography | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
- | EF Cryptography | [Mary Maller](https://github.com/mmaller) | 0.5 |
- | EF Cryptography | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
- | EF Consensus R&D | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 |
- | EF Consensus R&D | [Antonio Sanso](https://github.com/asanso/) | 1 |
- | EF Consensus R&D | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 |
- | EF Consensus R&D | [Dankrad Feist](https://github.com/dankrad/) | 1 |
- | EF Consensus R&D | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 |
- | EF Consensus R&D | [George Kadianakis](https://github.com/asn-d6/) | 1 |
- | EF Consensus R&D | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |
- | EF Consensus R&D | [Justin Drake](https://github.com/justindrake/) | 1 |
- | EF Consensus R&D | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 |
- | EF Consensus R&D | [Luca Zanolini](https://github.com/luca-zanolini) | 1 |
- | EF Consensus R&D | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
+ | Cryptography (EF) | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 |
+ | Cryptography (EF) | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
+ | Cryptography (EF) | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
+ | Cryptography (EF) | [Mary Maller](https://github.com/mmaller) | 0.5 |
+ | Cryptography (EF) | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
+ | Consensus R&D (EF) | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 |
+ | Consensus R&D (EF) | [Antonio Sanso](https://github.com/asanso/) | 1 |
+ | Consensus R&D (EF) | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 |
+ | Consensus R&D (EF) | [Dankrad Feist](https://github.com/dankrad/) | 1 |
+ | Consensus R&D (EF) | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 |
+ | Consensus R&D (EF) | [George Kadianakis](https://github.com/asn-d6/) | 1 |
+ | Consensus R&D (EF) | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |
+ | Consensus R&D (EF) | [Justin Drake](https://github.com/justindrake/) | 1 |
+ | Consensus R&D (EF) | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 |
+ | Consensus R&D (EF) | [Luca Zanolini](https://github.com/luca-zanolini) | 1 |
+ | Consensus R&D (EF) | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
  | Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
  | Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
  | Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
  | Robust Incentives Group (RIG) | [Davide Crapis](https://github.com/dcrapis/) | 1 |
  | Robust Incentives Group (RIG) | [Thomas Thiery](https://github.com/soispoke) | 1 |
  | Robust Incentives Group (RIG) | [Julian Ma](https://github.com/Ma-Julian) | 1 |
- | EF Protocol Security | [David Theodore](https://github.com/infosecual/) | 1 |
- | EF Protocol Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
- | EF Protocol Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
- | EF Protocol Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
- | EF Protocol Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
+ | Protocol Security (EF) | [David Theodore](https://github.com/infosecual/) | 1 |
+ | Protocol Security (EF) | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
+ | Protocol Security (EF) | [Justin Traglia](https://github.com/jtraglia/) | 1 |
+ | Protocol Security (EF) | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
+ | Protocol Security (EF) | [Yoav Weiss](https://github.com/yoavw/) | 1 |
  | Stateless Consensus | [Ignacio Hagopian](https://github.com/jsign/) | 1 |
  | Stateless Consensus | [Josh Rudolf](https://github.com/jrudolf/) | 1 |
- | EF Testing | [danceratopz](https://github.com/danceratopz) | 1 |
- | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
- | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |
+ | Testing (EF) | [danceratopz](https://github.com/danceratopz) | 1 |
+ | Testing (EF) | [Mario Vega](https://github.com/marioevz/) | 1 |
+ | Testing (EF) | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
  | Erigon | [Artem Tsebrovskii](https://github.com/awskii/) | 1 |


### PR DESCRIPTION
This PR corrects inaccurate project/team names or makes them more specific to the eligible work instead of the name of a funding/hosting org.

EF ARG → Applied Research Group (ARG)
EF Devops → ethPandaOps
EF Geth → Geth
EF Ipsilon → Ipsilon
EF Javascript → EthereumJS
EF Portal → Portal Network (EF)
EF Cryptography → Cryptography (EF)
EF Protocol Support → Protocol Support (EF)
EF Security → Protocol Security (EF)
EF Research → Consensus R&D (EF)
EF Robust Incentives Group (RIG) → Robust Incentives Group (RIG) 
EF Stateless Consensus → Stateless Consensus
Prysmatic → Prysm
Status → Nimbus
Status → Codex DAS
Consensys DDS → Dependable Distributed Systems (DDS)