### PR TITLE
Erigon: add Jacek Glen

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -89,6 +89,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Daniel Lazarenko](https://github.com/battlmonstr/) | 0.5 | Erigon | |
 | [Giulio Rebuffo](https://github.com/Giulio2002/) | 1 | Erigon | |
 | [lupin012](https://github.com/lupin012/) | 0.5 | Erigon | |
+| [Jacek Glen](https://github.com/jacekglen/) | 0.5 | Erigon | |
 | [Kairat Abylkasymov](https://github.com/racytech/) | 1 | Erigon | |
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
 | [Somnath Banerjee](https://github.com/somnathb1/) | 1 | Erigon | |


### PR DESCRIPTION
### Name
Jacek Glen
- GitHub: @jacekglen

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/erigontech/silkworm/commits?author=jacekglen
https://github.com/erigontech/rpc-tests/commits?author=jacekglen
https://github.com/ledgerwatch/erigon/commits?author=jacekglen

### Eligibility
Jacek has worked on our [Silkworm](https://github.com/erigontech/silkworm) project for almost 1 year now, actively contributing in the following areas:

- Unit testing based on Execution API Spec for JSON RPC daemon
- Request validation based on Execution API Spec in JSON RPC daemon
- Fuzz testing suite for JSON RPC daemon
- Fast historical block execution

He is currently working on fast block execution at the chain tip.

### Start Date
Jacek joined the Erigon team in May 2023.

### Proposed Weight
Partial. Jacek works on our projects more than 50% of his time but not 100%.
