### PR TITLE
Add Mark Holt from Erigon

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -91,6 +91,7 @@ The membership is a set of people working within the eligible projects who have 
 | [lupin012](https://github.com/lupin012/) | 0.5 | Erigon | |
 | [Jacek Glen](https://github.com/jacekglen/) | 0.5 | Erigon | |
 | [Kairat Abylkasymov](https://github.com/racytech/) | 1 | Erigon | |
+| [Mark Holt](https://github.com/mh0lt/) | 0.5 | Erigon | |
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
 | [Somnath Banerjee](https://github.com/somnathb1/) | 1 | Erigon | |
 | [Tullio Canepa](https://github.com/canepat/) | 1 | Erigon | |


### PR DESCRIPTION
### Name
Mark Holt

* GitHub: @mh0lt

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=mh0lt

### Eligibility
Mark has worked on Erigon for almost 1 year now, actively contributing in the following areas:

* BitTorrent snapshot downloader
* Metrics, testing & diagnostics tools
* txpool

### Start Date
Mark joined the Erigon team in June 2023.

### Proposed Weight
Partial. A lot of Mark's work benefits Erigon and Ethereum in general, but also Mark spends a substantial amount of his time on Polygon-specific tasks.

N.B. Mark is the leader of the Polygon sub-team in Erigon.
