### PR TITLE
adds my primary contributions, other edits to membership table

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -4,7 +4,7 @@
 
 The membership is a set of people working within the eligible projects who have also opted into Protocol Guild. As of the last onchain update (May 21, 2024) Protocol Guild had 177 members who cumulatively contributed over 600 years of effort to protocol stewardship. See the latest membership numbers [here](https://dune.com/protocolguild/protocol-guild#membership).
 
-| Name | Multiplier | Team | Eligible Work |
+| Name | Multiplier | Team | Primary Contributions |
 | :--- | :--- | :--- | :--- |
 | [Alex Stokes](https://github.com/ralexstokes/) | 1 | Applied Research Group (ARG) | |
 | [Echo](https://github.com/echoalice/) | 1 | Applied Research Group (ARG) | |
@@ -50,7 +50,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Peter Davies](https://github.com/ultratwo/) | 1 | Protocol Support (EF) | |
 | [Sam Wilson](https://github.com/SamWilsn/) | 1 | Protocol Support (EF) | |
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | Protocol Support (EF) | |
-| [Trenton Van Epps](https://github.com/tvanepps/) | 1 | Protocol Support (EF) | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
+| [Trenton Van Epps](https://github.com/tvanepps/) | 1 |  | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 | Cryptography (EF) | |
 | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
 | [Mark Simkin](https://msimkin.github.io) | 1 | Cryptography (EF) | |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -50,7 +50,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Peter Davies](https://github.com/ultratwo/) | 1 | Protocol Support (EF) | |
 | [Sam Wilson](https://github.com/SamWilsn/) | 1 | Protocol Support (EF) | |
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | Protocol Support (EF) | |
-| [Trenton Van Epps](https://github.com/tvanepps/) | 1 | Protocol Support (EF) | |
+| [Trenton Van Epps](https://github.com/tvanepps/) | 1 | Protocol Support (EF) | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 | Cryptography (EF) | |
 | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
 | [Mark Simkin](https://msimkin.github.io) | 1 | Cryptography (EF) | |


### PR DESCRIPTION
Following recent discussion on [github](https://github.com/protocolguild/documentation/pull/163) and elsewhere, the membership agreed to add an "eligible contributions" column to the membership table. Main rationale being that this info is more useful than org affiliation (to both members and the broader Ethereum community): it better describes what types of contributions the mechanism targets. It also reaffirms Protocol Guild's emphasis on individuals and their relevant work as being independent of the funding/hosting org.

This PR:

1. adds a link to the repo most closely relevant to my contributions in this markdown link format:[protocolguild/documentation] (https://github.com/protocolguild/documentation)
2. Deletes my org affiliation
3. renames the "Eligible Work" column to "Primary Contributions"

Members should do the same, choosing whichever example below fits best. There will likely be edge cases, but none that we can't figure out.

- Github: [org/repo] (github.com/org/repo)
- ethresearch: [ethresear.ch/u/username] (ethresear.ch/u/username)
- HackMD: [hackmd.io/@username] (hackmd.io/@username)

In the future we may also consider making it even more granular than a single link/repo, and require periodic refreshes (e.g. 3 link references from the past 3-6 months of work)