### PR TITLE
Add Carlos Bermudez Porto from Nethermind (part-time)

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -135,7 +135,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Alexey Osipov](https://github.com/flcl42) | 1 | Nethermind | [NethermindEth contributions](https://github.com/flcl42?org=NethermindEth)<br>[NethermindEth/nethermind PR's](https://github.com/NethermindEth/nethermind/pulls/flcl42) |
 | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 | Nethermind | |
 | [Ben Adams](https://github.com/benaadams) | 0.5 | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Abenaadams)|
-| [Carlos Bermudez Porto](https://github.com/cbermudez97) | 0.5 | Nethermind | |
+| [Carlos Bermudez Porto](https://github.com/cbermudez97) | 0.5 | | [NethermindEth contributions](https://github.com/cbermudez97?org=NethermindEth)<br>[NethermindEth/nethermind PR's](https://github.com/NethermindEth/nethermind/pulls?q=author%3Acbermudez97+)|
 | [Daniel Celeda](https://github.com/dceleda/) | 1 | Nethermind | |
 | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 | Nethermind | |
 | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 | Nethermind | |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -135,6 +135,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Alexey Osipov](https://github.com/flcl42) | 1 | Nethermind | |
 | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 | Nethermind | |
 | [Ben Adams](https://github.com/benaadams) | 0.5 | Nethermind | |
+| [Carlos Bermudez Porto](https://github.com/cbermudez97) | 0.5 | Nethermind | |
 | [Daniel Celeda](https://github.com/dceleda/) | 1 | Nethermind | |
 | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 | Nethermind | |
 | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 | Nethermind | |


### PR DESCRIPTION
**Name**: Carlos Bermudez
**Project**: Nethermind Client DevOps
**Team**: Nethermind
**Joined**: 01/01/2023
**Summary of their work/eligibility**: Carlos started working in Nethermind before the Merge. He is contributing as DevOps to the Infrastructure requirements for the Nethermind Client, especially in creating workflows for improving testing in the Post-Merge scenario. Other than that Carlos works heavily on tools which are beneficial not only for Nethermind development but for other EL/CL clients as well as for example Sedge which is one click solution for spawning all kind of combinations of clients (one oj the major tools used in our QA activities - speeds up work a lot). 

**Contributions:**
https://github.com/NethermindEth/nethermind/commits/master/?author=cbermudez97
https://github.com/NethermindEth/sedge/pulls?q=is%3Apr+author%3Acbermudez97 
https://github.com/NethermindEth/metrics-infrastructure/commits/master/?author=cbermudez97 
https://github.com/kurtosis-tech/ethereum-package/pulls?q=is%3Apr+author%3Acbermudez97

Other than above ones Carlos contributes a lot to currently private repositories which are about to be changed to public ones from which other EL/CL clients can benefit a lot like:
1. Tool to spin up all EL and CL clients in Virtualized environment in Linode and sync on all testnets and mainnet.
2. Creating a big library of playbooks in Ansible to easily maintain already created nodes.
3. Tool which allows to add new non validator nodes to existing devnets (very useful to test SnapSync etc on them without touching existing validators).
4. Infrastructure monitoring dashboard - tool where all spawned VMs with nodes installed can be browsed, edited (without need to interact directly on VM) or removed