### PR TITLE
Add Damian Orzechowski from Nethermind (full-time)

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -135,7 +135,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Alexey Osipov](https://github.com/flcl42) | 1 | Nethermind | [NethermindEth contributions](https://github.com/flcl42?org=NethermindEth)<br>[NethermindEth/nethermind PR's](https://github.com/NethermindEth/nethermind/pulls/flcl42) |
 | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 | Nethermind | |
 | [Ben Adams](https://github.com/benaadams) | 0.5 | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Abenaadams)|
-| [Damian Orzechowski](https://github.com/damian-orzechowski) | 1 | Nethermind | |
+| [Damian Orzechowski](https://github.com/damian-orzechowski) | 1 | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Adamian-orzechowski+) |
 | [Daniel Celeda](https://github.com/dceleda/) | 1 | Nethermind | |
 | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 | Nethermind | |
 | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 | Nethermind | |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -135,6 +135,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Alexey Osipov](https://github.com/flcl42) | 1 | Nethermind | |
 | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 | Nethermind | |
 | [Ben Adams](https://github.com/benaadams) | 0.5 | Nethermind | |
+| [Damian Orzechowski](https://github.com/damian-orzechowski) | 1 | Nethermind | |
 | [Daniel Celeda](https://github.com/dceleda/) | 1 | Nethermind | |
 | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 | Nethermind | |
 | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 | Nethermind | |


### PR DESCRIPTION
**Name**: Damian Orzechowski
**Project**: Ethereum Core Developer
**Team**: Nethermind
**Joined**: 03/10/2022
**Summary of their work/eligibility**: Damian started working in Nethermind after the Merge and begin with implementing EIP-3860 for the upcoming hard fork - Shanghai. Then he switched to R&D work related to state redesign and still continues to be involved in this area. His efforts include designing flat storage scheme for state access, participation in Verkle Tries transition and recently integrating sync capabilities for Paprika project. Damian is also taking part in Nethermind's internship programme, onboarding new joiners who are interested in learning Ethereum execution layer mechanisms.

**Contributions**:
https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3Adamian-orzechowski
https://github.com/NethermindEth/nethermind/pull/6499
https://github.com/NethermindEth/Paprika/pulls?q=is%3Apr+author%3Adamian-orzechowski