### PR TITLE
Add Bhargava Shastry

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -73,6 +73,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Davide Crapis](https://github.com/dcrapis/) | 1 | Robust Incentives Group (RIG) | |
 | [Thomas Thiery](https://github.com/soispoke/) | 1 | [research](https://ethresear.ch/u/soispoke/summary/) |
 | [Julian Ma](https://github.com/Ma-Julian) | 1 | Robust Incentives Group (RIG) | |
+• [Bhargava Shastry](https://github.com/bshastry/) | 1 | Protocol Security (EF) | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [David Theodore](https://github.com/infosecual/) | 1 | Protocol Security (EF) | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 | Protocol Security (EF) | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Justin Traglia](https://github.com/jtraglia/) | 1 | Protocol Security (EF) | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |


### PR DESCRIPTION
**Name**: Bhargava Shastry
**Project**: Ethereum Foundation
**Team**: Protocol Security (EF)
**Joined**: 01/01/2023
**Link to relevant work**: [https://github.com/bshastry](https://github.com/bshastry) **Summary of their work/eligibility**: Bhargava has been working full time in the EF since January 2019. He was working full-time as a security engineer for the Solidity team full-time until the end of 2023. In January 2023, he moved to the Protocol security team while still supporting Solidity. For the past six months he has been working full time to secure the Protocol by writing fuzzers and auditing the network layer. His current focus is the consensus later clients. Some of his contributions include
* private fuzzers for go-libp2p, go-multistream, go-multiformat, rust-libp2p, ethereum_ssz
* Prysm (https://github.com/prysmaticlabs/prysm/pull/14006), 
* public fuzzers for the Solidity compiler (https://github.com/ethereum/solidity/pulls?q=is%3Apr+author%3Abshastry+is%3Aclosed)
* Issues reported in Solidity compiler (https://github.com/ethereum/solidity/issues/created_by/bshastry)

Bhargava will have done his 6 months of full time protocol work on the 1st of August.