### PR TITLE
Add Eitan Seri-Levi

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -123,6 +123,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Jimmy Chen](https://github.com/jimmygchen) | 1 | Lighthouse | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Ajimmygchen) |
 | [João Oliveira](https://github.com/jxs) | 1 | Lighthouse | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Ajxs), [sigp/enr](https://github.com/sigp/enr/pulls?q=author%3Ajxs), [sigp/discv5](https://github.com/sigp/discv5/pulls?q=author%3Ajxs) |
 | [dapplion](https://github.com/dapplion/) | 1 | Lighthouse | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Adapplion), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=author%3Adapplion), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Adapplion) |
+| [Eitan Seri-Levi](https://github.com/eserilev/) | 1 | Lighthouse | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aeserilev) |
 | [Cayman Nava](https://github.com/wemeetagain/) | 1 | Lodestar | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Awemeetagain) |
 | [Gajinder Singh](https://github.com/g11tech/) | 1 | Lodestar | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Ag11tech) [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo/pulls?q=is%3Apr+author%3Ag11tech)|
 | [Matthew Keil](https://github.com/matthewkeil) | 1 | Lodestar | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Amatthewkeil) |


### PR DESCRIPTION
**Name**: Eitan Seri-Levi
**Project**: Lighthouse
**Team**: Sigma Prime/ Lighthouse
**Joined**: 29/01/2024 (However was an EPF fellow prior to this)
**Link to relevant work**: https://github.com/sigp/lighthouse/commits?author=eserilev
**Summary of their work/eligibility**: Eitan has been working on Lighthouse since late 2023. He was part of the Ethereum protocol fellowship and completed his project on Lighthouse and its dependencies. He joined the Lighthouse team in January this year and has made significant core contributions since. His knowledge and expertise has grown significantly, I think he would be a valued member of the Protocol Guild. 