### PR TITLE
Add a line about Ethereum values in Eligibility section

### DIFF
--- a/docs/01-eligibility.md
+++ b/docs/01-eligibility.md
@@ -2,6 +2,7 @@
 
 Protocol Guild eligible projects must:
 
+- Champion Ethereum's ethos of decentralization, credible neutrality, censorship resistance and permissionlessness
 - Be fully open source: both “source available” and free to fork, modify, redistribute
 - Have a regular presence in Ethereum R&D or governance venues, such as;
   - Specification repos (e.g. [consensus-specs](https://github.com/ethereum/consensus-specs), [execution-specs](https://github.com/ethereum/execution-specs), [execution-apis](https://github.com/ethereum/execution-apis))


### PR DESCRIPTION
PG [previously had language](https://github.com/protocolguild/docs/commit/a3e15aa589a33378906dec37da2d29258afe19a2#diff-64a5fe4221513cf9b544ac0ac40649337d36f7f153e5756c8df6dbe9cc1516daL25) in its eligibility section about projects being "committed to Ethereum and its ethos of decentralization". This was removed because it was judged to not be specific enough as a criteria. 

I believe we should add similar language again, in order to strengthen the norm that candidate PG projects not only "check all required the boxes" but also adhere to the same values around Ethereum as the current PG eligible projects. 

It's much easier to add this now, when everyone agrees, than in 5 years, when a team claims they "should be in" even though they don't meet this criteria 😄 