### PR TITLE
Add Milen Filatov from Erigon

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -93,6 +93,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Kairat Abylkasymov](https://github.com/racytech/) | 1 | Erigon | |
 | [Mark Holt](https://github.com/mh0lt/) | 0.5 | Erigon | |
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
+| [Milen Filatov](https://github.com/taratorio/) | 0.5 | | [ledgerwatch/erigon](https://github.com/ledgerwatch/erigon/pulls?q=author%3Ataratorio) |
 | [Somnath Banerjee](https://github.com/somnathb1/) | 1 | Erigon | |
 | [Tullio Canepa](https://github.com/canepat/) | 1 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Acanepat) [ledgerwatch/erigon](https://github.com/ledgerwatch/erigon/pulls?q=author%3Acanepat) |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | Ethereum Cat Herders | |


### PR DESCRIPTION
### Name
Milen Filatov

* GitHub: @taratorio

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=taratorio

### Eligibility
Milen's been working on Erigon for 8 months now, actively contributing in the following areas:

* `trace_*` and other RPC APIs
* Metrics, testing & diagnostics tools (e.g. sonarcloud)
* Erigon 3 optimizations (Elias-Fano iterator)

### Start Date
Milen joined the Erigon team in November 2023.

### Proposed Weight
Partial. A lot of Milen's work benefits Erigon and Ethereum in general, but also Milen spends a substantial amount of his time on Polygon-specific tasks.
