### PR TITLE
Remove fjl membership

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -19,7 +19,6 @@ The membership is a set of people working within the eligible projects who have 
 | [pk910](https://github.com/pk910/) | 1 | ethPandaOps | [ethPandaOps](https://github.com/ethpandaops) |
 | [Gary Rong](https://github.com/rjl493456442/) | 1 | Geth | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Arjl493456442+) |
 | [Guillaume Ballet](https://github.com/gballet/) | 1 | Geth | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Agballet) [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=is%3Apr+author%3Agballet) [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=is%3Apr+author%3Agballet) |
-| [Felix Lange](https://github.com/fjl/) | 1 | Geth | |
 | [Jared Wasinger](https://github.com/jwasinger/) | 1 | Geth | |
 | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 | Geth | |
 | [Matt Garnett](https://github.com/lightclient/) | 1 | Geth | |


### PR DESCRIPTION
Updating the membership to reflect that I am not a PGv2 member.
I am still an active member of the Ethereum community, but have chosen not to have
any ties with Protocol Guild in version 2.
