### PR TITLE
Remove Mark from Cryptography (EF)

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -50,7 +50,6 @@ The membership is a set of people working within the eligible projects who have 
 | [Trenton Van Epps](https://github.com/tvanepps/) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 | Cryptography (EF) | |
 | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
-| [Mark Simkin](https://msimkin.github.io) | 1 | Cryptography (EF) | |
 | [Mary Maller](https://github.com/mmaller) | 0.5 | Cryptography (EF) | |
 | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | Consensus R&D (EF) | |
 | [Antonio Sanso](https://github.com/asanso/) | 1 | Consensus R&D (EF) | |


### PR DESCRIPTION
Mark has moved on from Cryptography (EF)