### PR TITLE
Add Gottfried Herold

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -64,6 +64,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 | Consensus R&D (EF) | |
 | [Luca Zanolini](https://github.com/luca-zanolini) | 1 || [Research](https://github.com/luca-zanolini/research) |
 | [Pop Chunhapanya](https://github.com/ppopth/) | 1 | Consensus R&D (EF) | |
+| [Gottfried Herold]([https://github.com/ppopth/](https://github.com/GottfriedHerold) | 1 | Consensus R&D (EF) | |
 | [Anders](https://github.com/anderselowsson/) | 1 | Robust Incentives Group (RIG) | |
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | Robust Incentives Group (RIG) | |
 | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 | Robust Incentives Group (RIG) | |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -64,7 +64,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 | Consensus R&D (EF) | |
 | [Luca Zanolini](https://github.com/luca-zanolini) | 1 || [Research](https://github.com/luca-zanolini/research) |
 | [Pop Chunhapanya](https://github.com/ppopth/) | 1 | Consensus R&D (EF) | |
-| [Gottfried Herold]([https://github.com/ppopth/](https://github.com/GottfriedHerold) | 1 | Consensus R&D (EF) | |
+| [Gottfried Herold](https://github.com/GottfriedHerold) | 1 | Consensus R&D (EF) | |
 | [Anders](https://github.com/anderselowsson/) | 1 | Robust Incentives Group (RIG) | |
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | Robust Incentives Group (RIG) | |
 | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 | Robust Incentives Group (RIG) | |


### PR DESCRIPTION
# Name

Gottfried Herold

 * GitHub: @GottfriedHerold

# Team

Consensus R&D (EF)

# Link to some work

https://github.com/GottfriedHerold/Bandersnatch
https://github.com/ethereum/c-kzg-4844
https://www.iacr.org/cryptodb/data/paper.php?pubkey=34324

# Eligibility

Gottfried has been working on the Ethereum Research team for 3 years, working on several crypto library implementations relevant to Blobs and verkle tries. He has also worked on cryptography research.

# Start Date

Gottfried joined the Ethereum Research team in September 2021.

# Proposed Weight

Full. Gottfried Herold spends his full time doing Ethereum research