### PR TITLE
Fix typo in membership table

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -71,7 +71,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Davide Crapis](https://github.com/dcrapis/) | 1 | Robust Incentives Group (RIG) | |
 | [Thomas Thiery](https://github.com/soispoke/) | 1 | | [ethresearch](https://ethresear.ch/u/soispoke/summary/) |
 | [Julian Ma](https://github.com/Ma-Julian) | 1 | Robust Incentives Group (RIG) | |
-• [Bhargava Shastry](https://github.com/bshastry/) | 1 | | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
+| [Bhargava Shastry](https://github.com/bshastry/) | 1 | | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [David Theodore](https://github.com/infosecual/) | 1 | | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 | | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Justin Traglia](https://github.com/jtraglia/) | 1 | | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |


### PR DESCRIPTION
Adds a vertical line to delineate row entry instead of a dot character 