### PR TITLE
Add Saulius from Grandine

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -187,6 +187,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Mikhail Kalinin](https://github.com/mkalinin/) | 1 | | [ethresearch](https://ethresear.ch/u/mkalinin), [hackmd](https://hackmd.io/@n0ble), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Apr+author%3Amkalinin), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+author%3Amkalinin), [ethereum/execution-apis](https://github.com/ethereum/execution-apis/pulls?q=is%3Apr+author%3Amkalinin) |
 | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 | Dependable Distributed Systems (DDS) | |
 | [Chenyi Zhang](https://github.com/czhang-fm/) | 0.5 | Dependable Distributed Systems (DDS) | |
+| [Saulius Grigaitis](https://github.com/sauliusgrigaitis) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 
 *Note: Protocol Guild's [Split contract](https://app.splits.org/accounts/0xd4ad8daba9ee5ef16bb931d1cbe63fb9e102ec10/) contains all the above members plus one additional address used for entity expenses ([current address](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B), [former address](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99)).*
 


### PR DESCRIPTION
I'd like to nominate @sauliusgrigaitis, founder of the Grandine client, which was recently added as an eligible project (https://github.com/protocolguild/documentation/pull/246) given its transition to a fully OSS client. 

Name / Identifier: Saulius Grigaitis
Affiliated project they work on which is eligible: [Grandine](https://github.com/grandinetech/grandine), since 2019 (but eligible contributions post-OSS'ing Grandine, in March 2024)
Links to relevant eligible work, eg. GitHub, research: https://github.com/grandinetech/grandine/commits?author=sauliusgrigaitis
3-4 sentence summary of their contributions: Saulius has worked on Grandine from the start of the client's development and currently leads the team. 