### PR TITLE
Added Tumas from Grandine

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -187,6 +187,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 | Dependable Distributed Systems (DDS) | |
 | [Chenyi Zhang](https://github.com/czhang-fm/) | 0.5 | Dependable Distributed Systems (DDS) | |
 | [Saulius Grigaitis](https://github.com/sauliusgrigaitis) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
+| [Tumas](https://github.com/tumas) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 
 *Note: Protocol Guild's [Split contract](https://app.splits.org/accounts/0xd4ad8daba9ee5ef16bb931d1cbe63fb9e102ec10/) contains all the above members plus one additional address used for entity expenses ([current address](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B), [former address](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99)).*
 


### PR DESCRIPTION
# Name
Tumas

* GitHub: @tumas
 
# Team
Grandine
 
# Link to some work
https://github.com/grandinetech/grandine/commits?author=tumas

# Eligibility
Tumas has been working on the Grandine consensus client for more than 4 years (but eligible contributions post-OSS'ing Grandine, in March 2024) and was the fourth team member.
 
# Start Date
Tumas started to work on Grandine team in 2020 September.
 
# Proposed Weight
Full. Tumas spends his full time doing Grandine client development.
