### PR TITLE
Add Sudeep Kumar from Erigon

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -92,6 +92,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Mark Holt](https://github.com/mh0lt/) | 0.5 | Erigon | |
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
 | [Milen Filatov](https://github.com/taratorio/) | 0.5 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ataratorio) |
+| [M Sudeep Kumar](https://github.com/sudeepdino008/) | 1 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Asudeepdino008) 
 | [Somnath Banerjee](https://github.com/somnathb1/) | 1 | Erigon | |
 | [Tullio Canepa](https://github.com/canepat/) | 1 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Acanepat), [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Acanepat) |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | | [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/eips](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol)|


### PR DESCRIPTION
### Name
M Sudeep Kumar

### GitHub
@sudeepdino008

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=sudeepdino008

### Eligibility
Sudeep's been working on Erigon for 6 months now. Among other things, he's implemented [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).

### Start Date
Sudeep joined the Erigon team in April 2024.

### Proposed Weight
Full (1.0)
