### PR TITLE
Add Shoham Chakraborty from Erigon

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -93,6 +93,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
 | [Milen Filatov](https://github.com/taratorio/) | 0.5 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ataratorio) |
 | [Somnath Banerjee](https://github.com/somnathb1/) | 1 | Erigon | |
+| [Shoham Chakraborty](https://github.com/shohamc1/) | 0.5 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ashohamc1) |
 | [Tullio Canepa](https://github.com/canepat/) | 1 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Acanepat), [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Acanepat) |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | | [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/eips](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol)|
 | [Ameziane](https://github.com/ahamlat/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Aahamlat) |


### PR DESCRIPTION
### Name
Shoham Chakraborty

**GitHub**: @shohamc1

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=shohamc1

### Eligibility
Shoham's been working on Erigon for 9 months now, actively contributing in the following areas:

* Metrics, testing & diagnostics tools
* RPC API fixes (txfeecap, gas values in `debug_` methods)

### Start Date
Shoham joined the Erigon team in January 2024.

### Proposed Weight
Partial. A lot of Shoham's work benefits Erigon and Ethereum in general, but also Shoham spends a substantial amount of his time on Polygon-specific tasks.
