### PR TITLE
Add Kewei Chen from Erigon

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -89,6 +89,7 @@ The membership is a set of people working within the eligible projects who have 
 | [lupin012](https://github.com/lupin012/) | 0.5 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Alupin012), [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Alupin012), [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests/pulls?q=author%3Alupin012) |
 | [Jacek Glen](https://github.com/jacekglen/) | 0.5 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Ajacekglen), [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ajacekglen) |
 | [Kairat Abylkasymov](https://github.com/racytech/) | 1 | Erigon | |
+| [Kewei Chen](https://github.com/domiwei/) | 1 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Adomiwei) |
 | [Mark Holt](https://github.com/mh0lt/) | 0.5 | Erigon | |
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
 | [Milen Filatov](https://github.com/taratorio/) | 0.5 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ataratorio) |


### PR DESCRIPTION
### Name
Kewei Chen

**GitHub**: @domiwei

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=domiwei

### Eligibility
Kewei's been working on Erigon for 7 months now. He's been contributing a lot to Caplin, our CL implementation.

### Start Date
Kewei joined the Erigon team in March 2024.

### Proposed Weight
Full (1.0)
