### PR TITLE
Add Anders Kristiansen from Nethermind

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -130,6 +130,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Phil Ngo](https://github.com/philknows/) | 1 | | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Aphilknows) |
 | [Tuyen Nguyen](https://github.com/twoeths/) | 1 | | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Atwoeths) |
 | [Ahmad Bitar](https://github.com/smartprogrammer93 ) | 0.5 | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Asmartprogrammer93+) |
+| [Anders Kristiansen](https://github.com/ak88) | 0.5 |  Nethermind | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aak88) |
 | [Alexey Osipov](https://github.com/flcl42) | 1 |  | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aflcl42+) |
 | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 | Nethermind | |
 | [Ben Adams](https://github.com/benaadams) | 0.5 | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Abenaadams)|


### PR DESCRIPTION
 ### Name
Anders Kristiansen
 
**GitHub**: https://github.com/ak88
 
 ### Team
 [Nethermind](https://github.com/NethermindEth/nethermind)
 
 ### Link to some work
 https://github.com/NethermindEth/nethermind/pulls?q=author%3Aak88
 
 ### Eligibility
Anders joined Nethermind in November 2023 as an intern. He worked on ERA1 exports/imports and contributed to a tool used for testing blobs, which helped uncover bugs in different clients. He has worked on various bug fixes that have benefited Nethermind. Anders was also the main developer for EIPs 3074 and 7702.
 
 ### Start Date
Anders joined the Nethermind team in September 2023 as an intern and became a regular member in December 2023
 
 ### Proposed Weight
 Partial. Anders will be spending part of his time working on projects not related to Ethereum L1.