### PR TITLE
Add bhartnett from Nimbus

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -174,6 +174,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Jacek Sieka](https://github.com/arnetheduck/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aarnetheduck) |
 | [Jordan Hrycaj](https://github.com/mjfh/) | 1 | Nimbus | |
 | [Kim De Mey](https://github.com/kdeme/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Akdeme), [status-im/nimbus-eth1 Portal](https://github.com/status-im/nimbus-eth1/pulls?q=author%3Akdeme), [ethereum/portal-network-specs](https://github.com/ethereum/portal-network-specs/pulls?q=author%3Akdeme)|
+| [Ben Hartnett](https://github.com/bhartnett/) | 1 | | [status-im/nimbus-eth1 Portal](https://github.com/status-im/nimbus-eth1/pulls?q=author%3Abhartnett), [ethereum/portal-network-specs](https://github.com/ethereum/portal-network-specs/pulls?q=author%3Abhartnett)|
 | [Dmitrii Shmatko](https://github.com/zilm13/) | 1 | | [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Azilm13) |
 | [Enrico Del Fante](https://github.com/tbenr/) | 1 | | [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Atbenr) |
 | [Gabriel Fukushima](https://github.com/gfukushima/) | 1 | | [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Agfukushima) |


### PR DESCRIPTION
## Name
Ben Hartnett

## Github
https://github.com/bhartnett/

## Team
[Nimbus Portal](https://github.com/status-im/nimbus-eth1/tree/master/fluffy)

## Link to some work

- https://github.com/status-im/nimbus-eth1/pulls?q=author%3Abhartnett
- https://github.com/ethereum/portal-network-specs/pulls?q=author%3Abhartnett
- https://github.com/ethereum/hive/pulls?q=author%3Abhartnett

## Eligibility
Ben started in December 2023 with half-time work on the Nimbus Portal client, spending the rest of the half on Nimbus EL client (not eligible currently). He worked mostly on Portal state network & proof related code.
Since end of April 2024 he works full-time for the Nimbus Portal client.

## Start Date
Ben joined Nimbus in December 2023.

## Proposed Weight
Full. Ben works full time for the Nimbus Portal implementation.