### PR TITLE
Add Milos Stankovic

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -38,6 +38,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Jason Carver](https://github.com/carver/) | 1 | Portal Network (EF) | |
 | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 | Portal Network (EF) | |
 | [Mike Ferris](https://github.com/mrferris/) | 1 | Portal Network (EF) | |
+| [Milos Stankovic](https://github.com/morph-dev) | 1 | Portal Network (EF) | |
 | [Ognyan Genev](https://github.com/ogenev/) | 1 | |[ethereum/trin](https://github.com/ethereum/trin), [ethereum/portal-network-specs](https://github.com/ethereum/portal-network-specs)         |
 | [Piper Merriam](https://github.com/pipermerriam/) | 1 | Portal Network (EF) | |
 | [Nick Gheorghita](https://github.com/njgheorghita) | 1 | Portal Network (EF) | |


### PR DESCRIPTION
Name / identifier: [Milos Stankovic](https://github.com/morph-dev)
Team: Portal
Start date of relevant projects: [mid-January, 2024](https://github.com/morph-dev/trin/commit/0961ff64fb56204fc27b60ad9ec3873e79a2e392)
Proposed weight: Full (1.0)

## Short summary of their work / eligibility

Milos made his first part-time contribution in [October, 2023](https://github.com/morph-dev/trin/commit/a4f53c04368b5ab3983ec9145f8abdf1d94635af), while in an advanced degree program. 

Milos was able to upgrade to full-time work a few months later. He quickly made meaningful contributions to trin and the general protocol specs, and researched/designed/developed our first implementation of Verkle tries. We foresee him working full time on these and related projects, for the foreseeable future.

## Link to some work

Here is some recently merged code:

- https://github.com/ethereum/trin/pull/1579
- https://github.com/ethereum/trin/pull/1575
- https://github.com/ethereum/trin/pull/1562
- https://github.com/ethereum/trin/pull/1555

Milos is an active and contributing member of the trin team and the Portal project as a whole.