### PR TITLE
Add Benedikt Wagner 

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -49,7 +49,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Trenton Van Epps](https://github.com/tvanepps/) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 | Cryptography (EF) | |
 | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
-| [Benedikt Wagner](https://github.com/b-wagn) | 1 | Cryptography (EF) | |
+| [Benedikt Wagner](https://github.com/b-wagn) | 1 | Cryptography (EF) | https://github.com/b-wagn/pg-contrib/blob/main/README.md |
 | [Mark Simkin](https://msimkin.github.io) | 1 | | [research](https://github.com/msimkin/pglanding-mark/blob/main/README.md) |
 | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | Consensus R&D (EF) | |
 | [Antonio Sanso](https://github.com/asanso/) | 1 | Cryptography (EF) | [research](https://github.com/asanso/pglanding-asanso/blob/main/README.md) |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -48,8 +48,8 @@ The membership is a set of people working within the eligible projects who have 
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | | [ethereum/pm](https://github.com/ethereum/pm) |
 | [Trenton Van Epps](https://github.com/tvanepps/) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 | Cryptography (EF) | |
-| [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
 | [Benedikt Wagner](https://github.com/b-wagn) | 1 | Cryptography (EF) | https://github.com/b-wagn/pg-contrib/blob/main/README.md |
+| [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
 | [Mark Simkin](https://msimkin.github.io) | 1 | | [research](https://github.com/msimkin/pglanding-mark/blob/main/README.md) |
 | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | Consensus R&D (EF) | |
 | [Antonio Sanso](https://github.com/asanso/) | 1 | Cryptography (EF) | [research](https://github.com/asanso/pglanding-asanso/blob/main/README.md) |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -49,6 +49,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Trenton Van Epps](https://github.com/tvanepps/) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Arantxa Zapico](https://sites.google.com/view/arantxazapico/research) | 1 | Cryptography (EF) | |
 | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 | Cryptography (EF) | |
+| [Benedikt Wagner](https://github.com/b-wagn) | 1 | Cryptography (EF) | |
 | [Mark Simkin](https://msimkin.github.io) | 1 | | [research](https://github.com/msimkin/pglanding-mark/blob/main/README.md) |
 | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | Consensus R&D (EF) | |
 | [Antonio Sanso](https://github.com/asanso/) | 1 | Cryptography (EF) | [research](https://github.com/asanso/pglanding-asanso/blob/main/README.md) |


### PR DESCRIPTION
# Name
 Benedikt Wagner 
 
     * GitHub: @b-wagn
 
 # Team
 
 Cryptography (EF)

 # Link to some work
 
https://github.com/b-wagn/pg-contrib/blob/main/README.md

# Eligibility
 
Benedikt works as a cryptography researcher at the cryptography team of the Ethereum Foundation. 
 
# Start Date
 
Benedikt joined the Ethereum Research team in June 2024.
 
# Proposed Weight
 
 Full. Benedikt spends his full time doing Ethereum research

