### PR TITLE
Add Ilya Mikheev from Erigon 

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -88,6 +88,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Kairat Abylkasymov](https://github.com/racytech/) | 1 | Erigon | |
 | [Kewei Chen](https://github.com/domiwei/) | 1 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Adomiwei) |
 | [Mark Holt](https://github.com/mh0lt/) | 0.5 | Erigon | |
+| [Ilya Mikheev](https://github.com/JkLondon/) | 1 | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3AJkLondon) | |
 | [Michelangelo Riccobene](https://github.com/mriccobene/) | 1 | Erigon | |
 | [Milen Filatov](https://github.com/taratorio/) | 0.5 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ataratorio) |
 | [M Sudeep Kumar](https://github.com/sudeepdino008/) | 1 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Asudeepdino008) 


### PR DESCRIPTION
# Name

Ilya Mikheev

GitHub: @jklondon

# Team

[Erigon](https://github.com/ledgerwatch/erigon)

# Link to some work

https://github.com/ledgerwatch/erigon/commits?author=jklondon

# Eligibility

Ilya's been working on Erigon for 7 months now. He's been contributing a lot to Erigon3 data model and EL correctness.

# Start Date

Ilya joined the Erigon team in March 2024.

# Proposed Weight

Full (1.0)