### PR TITLE
Added Hangleang

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -194,6 +194,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Saulius Grigaitis](https://github.com/sauliusgrigaitis) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 | [Tumas](https://github.com/tumas) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 | [Povilas Liubauskas](https://github.com/povi) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
+| [Hangleang](https://github.com/hangleang/) | 0.5 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 
 
 *Note: Protocol Guild's [Split contract](https://app.splits.org/accounts/0xd4ad8daba9ee5ef16bb931d1cbe63fb9e102ec10/) contains all the above members plus one additional address used for entity expenses ([current address](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B), [former address](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99)).*


### PR DESCRIPTION
# Name
Hangleang SUN

* GitHub: @Hangleang
 
# Team
Grandine

# Link to some work
Merged https://github.com/grandinetech/grandine/commits/develop?author=hangleang
Most of Hangleang's work is on PeerDAS, so it's not merged yet - https://github.com/hangleang/grandine/commits/peerdas-fulu?author=hangleang

# Eligibility
Hangleang participated in EFP. During and after EFP he focused on Grandine's PeerDAS implementation.

# Start Date
Hangleang started to work on Grandine PeerDAS implementation in 2024 June.

# Proposed Weight
Half. Hangleang spends half time doing Grandine client development.
