### PR TITLE
Added Artiom Tretjakovas

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -194,6 +194,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Saulius Grigaitis](https://github.com/sauliusgrigaitis) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 | [Tumas](https://github.com/tumas) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
 | [Povilas Liubauskas](https://github.com/povi) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine)
+| [Artiom Tretjakovas](https://github.com/ArtiomTr/) | 0.5 | Grandine | [Grandine](https://github.com/grandinetech/grandine), [rust-kzg](https://github.com/grandinetech/rust-kzg/)
 
 
 *Note: Protocol Guild's [Split contract](https://app.splits.org/accounts/0xd4ad8daba9ee5ef16bb931d1cbe63fb9e102ec10/) contains all the above members plus one additional address used for entity expenses ([current address](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B), [former address](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99)).*


### PR DESCRIPTION
# Name
Artiom Tretjakovas

* GitHub: @ArtiomTr
 
# Team
Grandine

# Link to some work
https://github.com/grandinetech/rust-kzg/commits?author=ArtiomTr
https://github.com/grandinetech/grandine/commits?author=ArtiomTr
https://github.com/ArtiomTr/ggeth

# Eligibility
Artiom has been working on the Grandine consensus client since 2023 September (but eligible contributions post-OSS'ing Grandine, in March 2024). He mainly contributed to our own Rust KZG codebase (Grandine doesn't use `c-kzg-4844`) which further improved client diversity at the cryptography level for EIP-4844 and EIP-7594. Artiom is also working on some experimental things such as [embeddable Grandine embedded in Geth](https://github.com/ArtiomTr/ggeth).

# Start Date
Artiom started to work on Grandine team in 2023 September.

# Proposed Weight
Half. Artiom spends half time doing Grandine client development. He would like to upgrade to full-time soon and fully focus on Grandine.
