### PR TITLE
Add Luis Pinto

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -105,6 +105,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Gabriel Trintinalia](https://github.com/Gabriel-Trintinalia/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AGabriel-Trintinalia) |
 | [Jason Frame](https://github.com/jframe/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajframe) |
 | [Justin Florentine](https://github.com/jflo/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajflo) |
+| [Luis Pinto](https://github.com/lu-pinto/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Alu-pinto), [hyperledger/besu-verkle-trie](https://github.com/hyperledger/besu-verkle-trie/pulls?q=author%3Alu-pinto), [Consensys/tuweni](https://github.com/Consensys/tuweni/pulls?q=author%3Alu-pinto) |
 | [pinges](https://github.com/pinges/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |


### PR DESCRIPTION
Name: Luis Pinto
Project: Besu
Proposed Weight: Full

## Eligibility
- Full time developer working at [Besu](https://github.com/hyperledger/besu)
- Joined the Besu team in June 2024

### Jul -> Sep
- Started working on Besu:
[Commits](https://github.com/hyperledger/besu/commits/main/?author=lu-pinto&since=2024-07-01&until=2024-09-30)
[Issues](https://github.com/hyperledger/besu/issues/7704)

### Sep -> Today
#### Verkle
- Joined the Besu stateless team in September, working on fixing up gas costs for Verkle (EIP-6800, EIP-4762). Besu was able to follow the verkle devnet as a result of these efforts.
Refactored reference test framework in Besu to allow for running Verkle reference tests and pulling artifacts from a specific release branch in https://github.com/ethereum/execution-spec-tests.
[Besu Commits](https://github.com/hyperledger/besu/commits/verkle?author=lu-pinto&since=2024-09-18&until=2025-01-13)
[Besu-verkle-trie Commits](https://github.com/hyperledger/besu-verkle-trie/pulls?q=is%3Apr+is%3Aclosed+author%3Alu-pinto)
Issues - https://github.com/hyperledger/besu/issues/7705 https://github.com/hyperledger/besu/issues/7812

- Helped on improving verkle test reference coverage: https://github.com/ethereum/execution-spec-tests/pull/944 and found a few bugs in Geth and other clients in the process:
 https://github.com/gballet/go-ethereum/pull/508
 https://github.com/gballet/go-ethereum/pull/529

- Surfaced some issues with EIP-4762 for undocumented removal of CALLCODE cost of transferring value:
 https://github.com/ethereum/EIPs/pull/9124

#### EVMMAX
- Getting involved in EVMMAX looking to implement it on Besu:
 https://discord.com/channels/595666850260713488/1295427737183588363/1314232567125377078

#### Performance work
- Some ongoing performance work in Besu by cleaning up the Tuweni library that is primarily used by Besu and Teku:
 https://github.com/Consensys/tuweni/pull/17
 https://github.com/Consensys/tuweni/pull/18
 Performance improvements on Tuweni (internal PM repo issue #1010)

### Currently ongoing
- Finishing off EIP-7709 - this will bring a full green pass to verkle reference tests: https://github.com/hyperledger/besu/pull/7983
- Make all Besu tests go green on verkle branch including other forks, improving the developer experience overall: https://github.com/hyperledger/besu/pull/8089
- Refactoring Opcode execution result in EVM to make it explicitly in which exceptional cases is the gas cost useful: https://github.com/hyperledger/besu/pull/7919