### PR TITLE
Add compensation for Peter Vecchiarelli as Ops contributor

### DIFF
--- a/docs/06-entity-&-operations.md
+++ b/docs/06-entity-&-operations.md
@@ -20,6 +20,7 @@ The entity converts all tokens on a monthly basis to maintain a stablecoin reser
 - $100k in reserve for potential insurance claims against the foundation 
 - Compensation for independent operations contributors
     - $12.5k/month to support cheeky-gorilla's contributions
+    - $5k/month to support Peter Vechiarrelli's contributions
 
 Generally, the entity should receive sufficient funding to cover the above, but not accumulate beyond that. These amounts are set by the membership, as noted in the [Governance](https://protocol-guild.readthedocs.io/en/latest/02-membership.html#governance) subsection of the docs.
 

--- a/docs/06-entity-&-operations.md
+++ b/docs/06-entity-&-operations.md
@@ -20,7 +20,7 @@ The entity converts all tokens on a monthly basis to maintain a stablecoin reser
 - $100k in reserve for potential insurance claims against the foundation 
 - Compensation for independent operations contributors
     - $12.5k/month to support cheeky-gorilla's contributions
-    - $5k/month to support Peter Vechiarrelli's contributions
+    - $6k/month to support Peter Vechiarrelli's contributions
 
 Generally, the entity should receive sufficient funding to cover the above, but not accumulate beyond that. These amounts are set by the membership, as noted in the [Governance](https://protocol-guild.readthedocs.io/en/latest/02-membership.html#governance) subsection of the docs.
 


### PR DESCRIPTION
This PR adds a note that the Ops contributors intend to pay Peter Vecchiarelli (@pvechiarelli) $6k/month. He has been contributing since mid September, including:

- fundraising + filling out the CRM
- helping us maintain regular social media, creating media collateral (eg. parts of videos)
- representing the org on twitter spaces

See a detailed record of his ongoing work in the doc shared in the members discord. 