### PR TITLE
Add Agnish Ghosh

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -191,6 +191,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Saulius Grigaitis](https://github.com/sauliusgrigaitis) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine) |
 | [Tumas](https://github.com/tumas) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine) |
 | [Povilas Liubauskas](https://github.com/povi) | 1 | Grandine | [Grandine](https://github.com/grandinetech/grandine) |
+| [Agnish Ghosh](https://github.com/agnxsh) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aagnxsh) |
 
 
 *Note: Protocol Guild's [Split contract](https://app.splits.org/accounts/0xd4ad8daba9ee5ef16bb931d1cbe63fb9e102ec10/) contains all the above members plus one additional address used for entity expenses ([current address](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B), [former address](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99)).*


### PR DESCRIPTION
Name: Agnish Ghosh
Team: Nimbus (CL/nimbus-eth2)
Start time: 2024-01
Weight: 1

Eligibility:

Has been main contributor for Nimbus PeerDAS during both its Electra and Fulu phases.

Initially, he worked on Verkle and the [Kaustinen Devnet](https://github.com/status-im/nimbus-eth2/pull/6273), and has for the last several months shifted to working on KZG and PeerDAS, starting in May 2024. Since then, he's been the main person planning, designing, implementing, and testing [Nimbus's support for EIP-7594/PeerDAS](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aagnxsh), and now for that aspect of the Fulu fork, along with adjacent required changes to Nimbus.

Furthermore, this has included coordinating and working with the EF on ensuring that the `c-kzg-4844` library [properly supports PeerDAS](https://github.com/ethereum/c-kzg-4844/pull/482) and participating in the various PeerDAS testing calls, discussions, devnet, and spec planning and implementation (the [#peerdas-testing channel](https://discord.com/channels/595666850260713488/1252403418941624532) in the Eth R&D Discord, for example) both to improve the specs and ensure that Nimbus's implementation remains aligned with them.