### PR TITLE
add Bartosz Zawistowski

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -80,6 +80,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 | Erigon | |
 | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 | | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ayperbasis), [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Ayperbasis) |
 | [Artem Tsebrovskii](https://github.com/awskii/) | 1 | Erigon | |
+| [Bartosz Zawistowski](https://github.com/bzawisto/) | 1 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Abzawisto) |
 | [Daniel Lazarenko](https://github.com/battlmonstr/) | 1 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Abattlmonstr), [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Abattlmonstr) |
 | [Giulio Rebuffo](https://github.com/Giulio2002/) | 1 | Erigon | |
 | [lupin012](https://github.com/lupin012/) | 0.5 | | [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Alupin012), [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Alupin012), [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests/pulls?q=author%3Alupin012) |


### PR DESCRIPTION
Name: Bartosz Zawistowski
Team: Erigon
Start time: 2024-08
Weight: 1

Eligibility:
Bartosz has been working on our [Silkworm](https://github.com/erigontech/silkworm) project for more than 7 months now, contributing productively in the following areas:

- full implementation of Pectra support
- improvements in block and transaction processing
- maintenance and improvements in RPC daemon

Work:
https://github.com/erigontech/silkworm/commits?author=bzawisto