### PR TITLE
Add Dimitry from EF Testing

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -75,6 +75,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Ignacio Hagopian](https://github.com/jsign/) | 1 | | [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%3A%22jsign%22), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=author%3A%22jsign%22), [crate-crypto/go-ipa](https://github.com/crate-crypto/go-ipa/pulls?q=author%3A%22jsign%22)|
 | [Josh Rudolf](https://github.com/jrudolf/) | 1 | Stateless Consensus | |
 | [danceratopz](https://github.com/danceratopz) | 1 | | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
+| [winsvega](https://github.com/winsvega) | 0.5 | | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Mario Vega](https://github.com/marioevz/) | 1 | | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 0.5 | | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 | Erigon | |


### PR DESCRIPTION
## Name

Dimitry, aka [winsvega](https://github.com/winsvega).

## Team

Testing Team @ Ethereum Foundation

## Short summary of their work / eligibility

Dimitry was one of the first ethereum employees back in 2014. He joined ethereum aleth team (back then cpp-ethereum) and worked on testeth application that was used that time to make first evm json tests such as Blockchain and State tests .jsons.

After aleth discontinued, the testeth app was reformed as [retesteth](https://github.com/ethereum/retesteth) and was used to maintain, develop and generate all the test vectors from [tests](https://github.com/ethereum/tests)

Dimitry has developed and supported most of the tests from that repo among with retesteth and later t8n tool protocol that is now used to generate the tests.

Currently he is working on updating tests from `ethereum/tests` to `ethereum/execution-spec-tests` and also produces new tests for recent Prague EIPs.

## Link to some work

### Code

- Maintainer of [tests](https://github.com/protocolguild/documentation/pull/github.com/ethereum/tests)
- Maintainer of [retesteth](https://github.com/ethereum/retesteth) ([docs](http://retesteth.ethdevops.io/))
- [Execution-Spec-Tests](https://github.com/ethereum/execution-spec-tests/pulls?q=is%3Apr+is%3Amerged+author%3Awinsvega+) contributor/maintainer

### Talks

[Shanghai Devcon: Testing ethereum consensus](https://archive.devcon.org/archive/watch/2/testing-ethereum-consensus/?playlist=Devcon%202)
[Cancun Devcon: Ethereum protocol testing](https://archive.devcon.org/archive/watch/3/ethereum-protocol-testing/?playlist=Devcon%203)
### In progress / Planned

#### Currently working on:

- Mastering python tests format [pyspecs prs](https://github.com/ethereum/execution-spec-tests/pulls?q=+is%3Apr+author%3Awinsvega+)
- Supporing .json/.yml test vector updates with all ethereum hard fork upgrades
- Static test converter used to fill legacy files using EEST: https://github.com/ethereum/execution-spec-tests/pull/1362

#### Planned:

- Converting existing .json/.yml tests into .py tests
- Updating existent .json/.yml tests to Prague and beyond, until it's converted into .py, or can be filled using static converter

## Start date of relevant projects

December 1st, 2014 (EF team)
January 1st, 2024 (EF Testing team)

## Proposed weight (full or partial)

Partial*

*Dimitry has 2 little kids growing up that influence his availability hours