### PR TITLE
Add Peter Vecchiarelli as full member (Ops contributor)

### DIFF
--- a/docs/01-eligibility.md
+++ b/docs/01-eligibility.md
@@ -1,18 +1,19 @@
 # 1. Eligibility
 
-Protocol Guild eligible projects must:
+Protocol Guild eligible efforts must:
 
 - Champion Ethereum's ethos of decentralization, credible neutrality, censorship resistance and permissionlessness 
 - Be fully open source under an Open Source Initiative (OSI) [approved License](https://opensource.org/licenses)
 - Have a regular presence in Ethereum R&D or governance venues like [ethresear.ch](https://ethresear.ch), [Ethereum Magicians](https://ethereum-magicians.org/), [protocol calls](https://calendar.google.com/calendar/u/0?cid=Y191cGFvZm9uZzhtZ3JtcmtlZ243aWM3aGs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) (e.g. AllCoreDevs, breakouts, testing/interop, etc.)
 - Be engaged in feature prototyping (e.g. [EIPs](https://github.com/ethereum/eips), devnets, etc.)
+- Be centered on the strictly necessary and existential software required to produce blocks and advance the chain (eg. MEV boost and light clients are omitted here as they are not required for local block production and are not implicated in consensus activities). This includes the coordination work to test and roll out the software to the ecosystem as part of network upgrades.
 
 Eligible projects must also target at least one of the following projects/areas related to Ethereum core protocol upgrades, maintenance and development:
 
 | Description | Repos/Projects |
 |:--|:---|
 | Work on the canonical protocol specs. <br/> Should be implementation agnostic + unopinionated | - [Consensus specs](https://github.com/ethereum/consensus-specs) <br/> - [Execution specs (EELS)](https://github.com/ethereum/execution-specs) <br/> - [Execution APIs](https://github.com/ethereum/execution-apis)  |
-| Ethereum mainnet client implementations. <br/> Must be well-tested, technically differentiated, <br/>  and production ready | - [Erigon](https://github.com/erigontech/erigon) <br/> - [EthereumJS](https://github.com/ethereumjs) <br/> - [Geth](https://github.com/ethereum/go-ethereum) <br/> - [Grandine](https://github.com/grandinetech/grandine) <br/> - [Hyperledger Besu](https://github.com/hyperledger/besu) <br/> - [Lighthouse](https://github.com/sigp/lighthouse) <br/> - [Lodestar](https://github.com/ChainSafe/lodestar) <br/> - [Nethermind](https://github.com/NethermindEth/nethermind) <br/> - [Nimbus CL](https://github.com/status-im/nimbus-eth2) <br/> - [Nimbus EL](https://github.com/status-im/nimbus-eth1) <br/> - [Prysm](https://github.com/prysmaticlabs/prysm) <br/> - [Teku](https://github.com/ConsenSys/teku) <br/> - [Reth](https://github.com/paradigmxyz/reth) |
+| Ethereum mainnet Execution and <br/> Consensus client implementations. <br/> Must be well-tested, technically differentiated, <br/>  and have production-ready releases <br/> (ie. ability to construct full blocks locally) | - [Erigon](https://github.com/erigontech/erigon) <br/> - [EthereumJS](https://github.com/ethereumjs) <br/> - [Geth](https://github.com/ethereum/go-ethereum) <br/> - [Grandine](https://github.com/grandinetech/grandine) <br/> - [Hyperledger Besu](https://github.com/hyperledger/besu) <br/> - [Lighthouse](https://github.com/sigp/lighthouse) <br/> - [Lodestar](https://github.com/ChainSafe/lodestar) <br/> - [Nethermind](https://github.com/NethermindEth/nethermind) <br/> - [Nimbus CL](https://github.com/status-im/nimbus-eth2) <br/> - [Nimbus EL](https://github.com/status-im/nimbus-eth1) <br/> - [Prysm](https://github.com/prysmaticlabs/prysm) <br/> - [Teku](https://github.com/ConsenSys/teku) <br/> - [Reth](https://github.com/paradigmxyz/reth) |
 | Client testing/security/infra <br/> which supports these implementations | - [ethereum/tests](https://github.com/ethereum/tests) <br/> - [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | Network upgrade coordination  | - [ethereum/pm](https://github.com/ethereum/pm) |
 | Research and implementation experiments <br/> related to potential protocol changes | - [Verkle trees](https://github.com/gballet/go-verkle) (Verge) <br/> - [Portal Network](https://github.com/ethereum/portal-network-specs) (Purge) <br/> - [Ipsilon](https://github.com/ipsilon) (EVM Improvements) <br/> - Consensus work <br/> - Cryptography <br/> - Mechanism design <br/> - Resource pricing |

--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -108,6 +108,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |
 | [cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
+| [Peter Vecchiarelli](https://github.com/pvecchiarelli) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
 | [Adrian Manning](https://github.com/AgeManning/) | 0.5 | Lighthouse | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3AAgeManning), [sigp/enr](https://github.com/sigp/enr/pulls?q=author%3AAgeManning), [sigp/discv5](https://github.com/sigp/discv5/pulls?q=author%3AAgeManning) |
 | [Mac Ladson](https://github.com/macladson/) | 1 | | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amacladson) |
 | [Mark Mackey](https://github.com/ethDreamer/) | 1 | | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3AethDreamer) |


### PR DESCRIPTION
Name: Peter Vecchiarelli
Start time: 2024-09
Weight: 1

Eligibility:

- fundraising outreach
- partnership strategy
- regular social media (twitter/X + farcaster), creating media collateral (eg. parts of videos), "24 hours in core dev" thread series
- representing the org on twitter spaces
- staffing the Devcon booth

The ops team is thrilled to have another generalist join the team in this capacity! A detailed record of his ongoing work can be seen in the doc shared in the members discord. Given he was not part of another org supporting his work, we have provided stable monthly funding ahead of full membership. PRs linked below:

- Jan 2025, [$6k/month](https://github.com/protocolguild/documentation/pull/311) 
- March 2025, [$10.5k/month](https://github.com/protocolguild/documentation/pull/328) 