### PR TITLE
Add Peter Vecchiarelli as Ops Contributor

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -108,6 +108,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |
 | [cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 | | [protocolguild/documentation](https://github.com/protocolguild/documentation) |
+| [Peter Vecchiarelli](https://github.com/pvecchiarelli) | 1 | | [protocolguild/documentation]([https://github.com/protocolguild/documentation](https://github.com/protocolguild/documentation/pulls?q=is%3Apr+author%3Apvecchiarelli+)) |
 | [Adrian Manning](https://github.com/AgeManning/) | 0.5 | Lighthouse | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3AAgeManning), [sigp/enr](https://github.com/sigp/enr/pulls?q=author%3AAgeManning), [sigp/discv5](https://github.com/sigp/discv5/pulls?q=author%3AAgeManning) |
 | [Mac Ladson](https://github.com/macladson/) | 1 | | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amacladson) |
 | [Mark Mackey](https://github.com/ethDreamer/) | 1 | | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3AethDreamer) |


### PR DESCRIPTION
_closed a [previous version](https://github.com/protocolguild/documentation/pull/333) of this PR, reopening here_

Add Peter Vecchiarelli as full member (Ops contributor) Name: Peter Vecchiarelli
Start time: 2024-09
Weight: 1

Eligibility:

- fundraising outreach
- partnership strategy
- regular social media (twitter/X + farcaster), creating media collateral (eg. parts of videos), "24 hours in core dev" thread series
- representing the org on twitter spaces
- staffing the Devcon booth

The ops team is thrilled to have another generalist join the team in this capacity! A detailed record of his ongoing work can be seen in the doc shared in the members discord.

Past PRs to provide stable monthly funding ahead of full membership:

- Jan 2025 [$6k/month](protocolguild#311)
- March 2025 [$10.5k/month](protocolguild#328)