### PR TITLE
Add Matt Evans from ethPandaOps

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -16,6 +16,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Barnabas Busa](https://github.com/barnabasbusa/) | 1 | | [ethPandaOps](https://github.com/ethpandaops) |
 | [Andrew Davis](https://github.com/savid/) | 1 | | [ethPandaOps](https://github.com/ethpandaops) |
 | [pk910](https://github.com/pk910/) | 1 | | [ethPandaOps](https://github.com/ethpandaops) |
+| [Matt Evans](https://github.com/mattevans/) | 1 | | [ethPandaOps](https://github.com/ethpandaops) |
 | [Gary Rong](https://github.com/rjl493456442/) | 1 | | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Arjl493456442+) |
 | [Guillaume Ballet](https://github.com/gballet/) | 1 |  | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Agballet), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=is%3Apr+author%3Agballet), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=is%3Apr+author%3Agballet) |
 | [Jared Wasinger](https://github.com/jwasinger/) | 1 | Geth | |


### PR DESCRIPTION
**Name / identifier**: [Matt Evans](https://github.com/mattevans)
**Team**: ethPandaOps
**Start date of relevant projects**: November 2024
Proposed weight: Full (1.0)

### Short summary of their work / eligibility
Matty joined our team last year and has made an immediate impact. While his primary focus is on custom tooling and application development, the team increasingly draws on his extensive knowledge across multiple parts of our stack.

In his first 6 months Matty has been mostly been working on our data pipeline. This pipeline provides our team with direct observability of Mainnet, and is an invaluable resource for researchoors and analysts looking to make informed decisions about Layer 1. His recent work with Contributoor is especially impactful, allowing our team to capture data from from home users in a privacy orientated and user friendly way that wasn't possible before.

### Link to some work
- Created [Contributoor](https://github.com/ethpandaops/contributoor) and [Contributoor Installer](https://github.com/ethpandaops/contributoor-installer), massively streamlining the process of onboarding home users to provide data to ethPandaOps.
- Created [Panda Pulse](https://github.com/ethpandaops/panda-pulse), which alerts in to the Eth R&D Discord across multiple networks with user-driven configuration built in.
- [Many, many changes to Xatu](https://github.com/ethpandaops/xatu/pulls?q=is%3Apr+is%3Aclosed+author%3Amattevans).
- Various changes to [Hermes](https://github.com/probe-lab/hermes), which our team uses for monitoring the consensus layer p2p layer - [1](https://github.com/probe-lab/hermes/pull/40), [2](https://github.com/probe-lab/hermes/pull/51), [3](https://github.com/probe-lab/hermes/pull/54). 

**Matty has been working with the team on a full time basis, so I would propose him with a full weight (1.0)**
