### PR TITLE
Add Matilda Clerke from Besu

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -104,6 +104,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Jason Frame](https://github.com/jframe/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajframe) |
 | [Justin Florentine](https://github.com/jflo/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajflo) |
 | [Luis Pinto](https://github.com/lu-pinto/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Alu-pinto), [hyperledger/besu-verkle-trie](https://github.com/hyperledger/besu-verkle-trie/pulls?q=author%3Alu-pinto), [Consensys/tuweni](https://github.com/Consensys/tuweni/pulls?q=author%3Alu-pinto) |
+| [Matilda Clerke](https://github.com/Matilda-Clerke/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AMatilda-Clerke) |
 | [pinges](https://github.com/pinges/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |


### PR DESCRIPTION
Name: Matilda Clerke
Project: Besu
Proposed Weight: Full
Start Date: July 2024

### Eligibility
Matilda has been working on Besu since July 2024 and has been contributing to
* Peering improvements in Besu
* RPC error handling and new endpoints
* Implementing history expiry

PRs [hyperledger/besu/pulls](https://github.com/hyperledger/besu/pulls?q=author%3AMatilda-Clerke)

July 2024:
- [Clean up deprecated experimental sync modes](https://github.com/hyperledger/besu/pull/7309)
- [Renaming of datagas to blobgas Besu](https://github.com/hyperledger/besu/pull/7353)
- [Add WithdrawalRequestPredeployAddress to the genesis configuration](
https://github.com/hyperledger/besu/pull/7356)

August 2024:
- [Refactor Besu RPC error handling for better error reporting](https://github.com/hyperledger/besu/pull/7389)

September 2024:
- [Implement engine_getClientVersionV1, including build hash](https://github.com/hyperledger/besu/pull/7548)
October 2024 to January 2025:
- [Build a simplified (in code terms) peer to peer communication system for Besu](	https://github.com/hyperledger/besu/pull/7628)

February 2025:
- [Validate node records (response to hackathon discovered vulnerability)](		https://github.com/Consensys/discovery/pull/185)
- [Validate packet data expiry](https://github.com/hyperledger/besu/pull/8186)
- [Refactor packet data classes in Besu for easier testing and dependency injection](		https://github.com/hyperledger/besu/pull/8271)

March 2025 to April 2025:
- Leading technical implementation of history expiry (EIP-4444) in besu
- [Adding pre-merge block import from ERA1 files](https://github.com/hyperledger/besu/pull/8352)
- [Add pruning subcommand to prune pre-merge blocks](https://github.com/hyperledger/besu/pull/8388)
- Implement online pruning of pre-merge blocks ](https://github.com/hyperledger/besu/pull/8493)