### PR TITLE
Add Arsenii Kulikov

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -163,6 +163,7 @@ The membership is a set of people working within the eligible projects who have 
 | [joshie](https://github.com/joshieDo) | 0.5 | Reth | [Reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3AjoshieDo)
 | [Matthias Seitz](https://github.com/mattsse/) | 0.5 | Reth | |
 | [Roman Krasiuk](https://github.com/rkrasiuk) | 0.5 | Reth | |
+| [Arsenii Kulikov](https://github.com/klkvr)  | 0.5 | Reth |[Reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr) |
 | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 | Codex DAS | |
 | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 | | [ethresearch](https://ethresear.ch/u/cskiraly/) |
 | [Leonardo Bautista-Gomez](https://github.com/leobago/) | 0.5 | | [ethresearch](https://ethresear.ch/u/leobago/) |


### PR DESCRIPTION
Name: Arsenii Kulikov
Project: Reth
Proposed Weight: 0.5
Start Date: August 2024

Eligibility
Arsenii has been working on Reth since August 2024 and has been instrumental to shipping Pectra and worked across the stack, did various bug fixes, testing, and complete redesigns.

All PRs in reth and the EVM
[paradigmxyz/reth/pulls](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr)
[bluealloy/revm](https://github.com/bluealloy/revm/pulls?q=is%3Apr+author%3Aklkvr)

Excerpts
* EIP-7702 authorizations [alloy/eips/pulls](https://github.com/alloy-rs/eips/pulls?q=is%3Apr+is%3Aclosed+author%3Aklkvr)
* Block Execution redesign and features https://github.com/paradigmxyz/reth/pull/11144 https://github.com/paradigmxyz/reth/pull/14021 https://github.com/paradigmxyz/reth/pull/14480
* eth_simulateV1 implementation https://github.com/paradigmxyz/reth/pull/10829
* EIP-7840 support https://github.com/alloy-rs/alloy/pull/1828
* EIP-7691 support https://github.com/alloy-rs/alloy/pull/1762
