### PR TITLE
add Kanchan Kaur partial weight

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -102,6 +102,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Gabriel Trintinalia](https://github.com/Gabriel-Trintinalia/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AGabriel-Trintinalia) |
 | [Jason Frame](https://github.com/jframe/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajframe) |
 | [Justin Florentine](https://github.com/jflo/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajflo) |
+| [Kanchan Kaur](https://github.com/kkaur01) | 0.5 | |  [hyperledger/besu](https://github.com/hyperledger/besu) |
 | [Luis Pinto](https://github.com/lu-pinto/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Alu-pinto), [hyperledger/besu-verkle-trie](https://github.com/hyperledger/besu-verkle-trie/pulls?q=author%3Alu-pinto), [Consensys/tuweni](https://github.com/Consensys/tuweni/pulls?q=author%3Alu-pinto) |
 | [pinges](https://github.com/pinges/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |


### PR DESCRIPTION
Name: Kanchan Kaur
Project: Besu
Proposed Weight: 0.5
Start Date: October 2024

Eligibility

Kanchan Kaur has been Engineering Manager for Consensys Protocols for the last 3+ years. This includes Besu and Consensys R&D Ethereum researchers. In this role, she has been working with Besu and Consensys R&D since before the Merge to:
* Schedule working priorities and manage workloads
* Collaborate with engineers and PM to produce and communicate product roadmap
* Manage team-wide processes and foster continuous improvement
* Facilitate retrospectives and post-mortems
* Determine R&D focus areas
* Facilitate work on Verkle and statelessness
* Co-ordinate between Consensys Protocols and EF to enable attendance and participation for DevCon, DevConnect, and interop events
* Handle team administration to free up engineering overhead, including logistics and travel for in-person events; co-ordinating internal milestones with Ethereum network upgrade timelines; co-ordinating responses to ecosystem-wide incidents.

Kanchan co-ordinates Besu and Consensys R&D opinions, roadmap and priorities, which requires cat-herding of Consensys teams like MetaMask and Infura, to gather their input. 

Kanchan also works with various documentation and news publications via Consensys and Hyperledger/LFDT PR to provide educational content around protocol upgrades, Ethereum R&D topics, and more. Example https://www.lfdecentralizedtrust.org/blog/reflecting-on-2024-and-shaping-the-future-of-besu