### PR TITLE
add Advaita Saha

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -168,6 +168,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 | Codex DAS | |
 | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 | | [ethresearch](https://ethresear.ch/u/cskiraly/) |
 | [Leonardo Bautista-Gomez](https://github.com/leobago/) | 0.5 | | [ethresearch](https://ethresear.ch/u/leobago/) |
+| [Advaita Saha ](https://github.com/advaita-saha) | 1 | | [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/pulls?q=author%3Aadvaita-saha) |
 | [Agnish Ghosh](https://github.com/agnxsh) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aagnxsh) |
 | [Dustin Brody](https://github.com/tersec/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Atersec) |
 | [Etan Kissling](https://github.com/etan-status/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aetan-status), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=author%3Aetan-status), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Aetan-status) |


### PR DESCRIPTION
Name: Advaita Saha
Team: Nimbus (EL/nimbus-eth1)
Start time: 2024-01
Weight: 1

Eligibility:

Initially, Advaita [worked on EIP-6800 Verkle trees](https://github.com/status-im/nim-eth-verkle/commits?author=advaita-saha), including [in the underlying Constantine cryptography library](https://github.com/mratsim/constantine/commits?author=advaita-saha) which was being used to for cryptographic primitives. As work on that wound down, he expanded his `nimbus-eth1` efforts to Hive and Kurtosis testing, Era file support, engine API, syncing, RPC, and [an increasing range of functionality](https://github.com/status-im/nimbus-eth1/pulls?q=author%3Aadvaita-saha), becoming one of the main contributors to the Nimbus EL.

In addition, he has both internally within the Nimbus team and externally with the EF and other interested parties coordinated and developed Kurtosis and Hive testing support in both the Nimbus CL and EL, adding and maintaining a Kurtosis test runner to the Nimbus EL CI, as well Hive instances for ongoing spec compliance testing. This has solidified both the regression testing and new EIP compliance testing Nimbus EL undergoes, and it's partly due to these efforts one can be confident it is and will remain a substantially spec-compliant EL client today.