### PR TITLE
add Andri Lim

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -169,6 +169,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Csaba Kiraly](https://github.com/cskiraly/) | 0.5 | | [ethresearch](https://ethresear.ch/u/cskiraly/) |
 | [Leonardo Bautista-Gomez](https://github.com/leobago/) | 0.5 | | [ethresearch](https://ethresear.ch/u/leobago/) |
 | [Agnish Ghosh](https://github.com/agnxsh) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aagnxsh) |
+| [Andri Lim](https://github.com/jangko) | 1 | | [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/commits?author=jangko) |
 | [Dustin Brody](https://github.com/tersec/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Atersec) |
 | [Etan Kissling](https://github.com/etan-status/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Aetan-status), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=author%3Aetan-status), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Aetan-status) |
 | [Eugene Kabanov](https://github.com/cheatfate/) | 1 | | [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=author%3Acheatfate) |


### PR DESCRIPTION
Name: Andri Lim
Team: Nimbus (EL/nimbus-eth1)
Start time: 2018-01
Weight: 1

Eligibility:

Andri has extensively contributed to the Nimbus EL [since almost the beginning of the project](https://github.com/status-im/nimbus-eth1/commits?since=2018-12-01&until=2019-01-10&author=jangko) and [continues to do so to this day](https://github.com/status-im/nimbus-eth1/commits?author=jangko). For years, he was either effectively its sole contributor or one of two people involved, and thus has worked across the entire codebase and supporting library set, including but not limited to the EVM, database, transaction pool, RPC and engine API implementations, wire protocols, initial usage of Hive-based tests for testing, and at least dozens of EIPs, all the way from before the merge to Pectra and Fusaka, 