### PR TITLE
add more specificity to project-level eligibility

### DIFF
--- a/docs/01-eligibility.md
+++ b/docs/01-eligibility.md
@@ -1,18 +1,17 @@
 # 1. Eligibility
 
-Protocol Guild eligible projects must:
+Protocol Guild eligible efforts must be:
 
-- Champion Ethereum's ethos of decentralization, credible neutrality, censorship resistance and permissionlessness 
-- Be fully open source under an Open Source Initiative (OSI) [approved License](https://opensource.org/licenses)
-- Have a regular presence in Ethereum R&D or governance venues like [ethresear.ch](https://ethresear.ch), [Ethereum Magicians](https://ethereum-magicians.org/), [protocol calls](https://calendar.google.com/calendar/u/0?cid=Y191cGFvZm9uZzhtZ3JtcmtlZ243aWM3aGs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) (e.g. AllCoreDevs, breakouts, testing/interop, etc.)
-- Be engaged in feature prototyping (e.g. [EIPs](https://github.com/ethereum/eips), devnets, etc.)
-
-Eligible projects must also target at least one of the following projects/areas related to Ethereum core protocol upgrades, maintenance and development:
+- Champions of Ethereum's ethos of decentralization, credible neutrality, censorship resistance and permissionlessness 
+- Fully open source under an Open Source Initiative (OSI) [approved License](https://opensource.org/licenses)
+- Regular attendees of Ethereum R&D or governance venues like [ethresear.ch](https://ethresear.ch), [Ethereum Magicians](https://ethereum-magicians.org/), [protocol calls](https://calendar.google.com/calendar/u/0?cid=Y191cGFvZm9uZzhtZ3JtcmtlZ243aWM3aGs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) (e.g. AllCoreDevs, breakouts, testing/interop, etc.)
+- Engaged in feature prototyping (e.g. [EIPs](https://github.com/ethereum/eips), devnets, etc.)
+- Centered on the strictly necessary and existential software required to produce blocks and advance the chain (eg. MEV boost and light clients are omitted here as they are not required for local block production and are not implicated in consensus activities). This includes the coordination work to test and roll out the software to the ecosystem as part of network upgrades. Consider the table below:
 
 | Description | Repos/Projects |
 |:--|:---|
 | Work on the canonical protocol specs. <br/> Should be implementation agnostic + unopinionated | - [Consensus specs](https://github.com/ethereum/consensus-specs) <br/> - [Execution specs (EELS)](https://github.com/ethereum/execution-specs) <br/> - [Execution APIs](https://github.com/ethereum/execution-apis)  |
-| Ethereum mainnet client implementations. <br/> Must be well-tested, technically differentiated, <br/>  and production ready | - [Erigon](https://github.com/erigontech/erigon) <br/> - [EthereumJS](https://github.com/ethereumjs) <br/> - [Geth](https://github.com/ethereum/go-ethereum) <br/> - [Grandine](https://github.com/grandinetech/grandine) <br/> - [Hyperledger Besu](https://github.com/hyperledger/besu) <br/> - [Lighthouse](https://github.com/sigp/lighthouse) <br/> - [Lodestar](https://github.com/ChainSafe/lodestar) <br/> - [Nethermind](https://github.com/NethermindEth/nethermind) <br/> - [Nimbus CL](https://github.com/status-im/nimbus-eth2) <br/> - [Nimbus EL](https://github.com/status-im/nimbus-eth1) <br/> - [Prysm](https://github.com/prysmaticlabs/prysm) <br/> - [Teku](https://github.com/ConsenSys/teku) <br/> - [Reth](https://github.com/paradigmxyz/reth) |
+| Ethereum mainnet Execution and <br/> Consensus client implementations. <br/> Must be well-tested, technically differentiated, <br/>  and have production-ready releases <br/> (ie. ability to construct full blocks locally) | - [Erigon](https://github.com/erigontech/erigon) <br/> - [EthereumJS](https://github.com/ethereumjs) <br/> - [Geth](https://github.com/ethereum/go-ethereum) <br/> - [Grandine](https://github.com/grandinetech/grandine) <br/> - [Hyperledger Besu](https://github.com/hyperledger/besu) <br/> - [Lighthouse](https://github.com/sigp/lighthouse) <br/> - [Lodestar](https://github.com/ChainSafe/lodestar) <br/> - [Nethermind](https://github.com/NethermindEth/nethermind) <br/> - [Nimbus CL](https://github.com/status-im/nimbus-eth2) <br/> - [Nimbus EL](https://github.com/status-im/nimbus-eth1) <br/> - [Prysm](https://github.com/prysmaticlabs/prysm) <br/> - [Teku](https://github.com/ConsenSys/teku) <br/> - [Reth](https://github.com/paradigmxyz/reth) |
 | Client testing/security/infra <br/> which supports these implementations | - [ethereum/tests](https://github.com/ethereum/tests) <br/> - [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | Network upgrade coordination  | - [ethereum/pm](https://github.com/ethereum/pm) |
 | Research and implementation experiments <br/> related to potential protocol changes | - [Verkle trees](https://github.com/gballet/go-verkle) (Verge) <br/> - [Portal Network](https://github.com/ethereum/portal-network-specs) (Purge) <br/> - [Ipsilon](https://github.com/ipsilon) (EVM Improvements) <br/> - Consensus work <br/> - Cryptography <br/> - Mechanism design <br/> - Resource pricing |


### PR DESCRIPTION
This PR adds two notes to make project-level eligibility more explicit:

- strictly necessary software for ethereum to come to consensus
- clients must be able to produce blocks locally to be considered

Members can see the original discussion and notes from the April 1st internal ops call - see [this internal discord message](https://discord.com/channels/795514951376568391/921398464884121630/1356937217406406787
) for summary and notes

> zkEVM/zkVM formal verification eligibility: Trent shared a proposed update to PGs eligibility framework, see the above link for the updated wording. 
> - The goal is to make PG eligibility as explicit as possible, by anchoring on "strictly necessary and existential software required to produce blocks and advance the chain"
> - MEV boost and light clients are highlighted as two projects that are not eligible (we have been approached by a couple light clients about inclusion in the past)
> - Changes to the word were also made to ensure that we set a high bar for new clients, including that their releases are "production-grade" (not pre-releases) and that the client can construct full blocks. 
> - Note that the proposed wording could be interpreted to exclude Portal clients (though Portal is not referenced), but this proposed change is not meant to make a decision on that, Portal clients would remain grandfathered into PG as part of this change. However, there are separate discussions on the eligibility of Portal clients, see [here](https://discord.com/channels/795514951376568391/1336722194629136466/1353774960191213579). 
> - This change is the first step in overhauling PGs eligibility to account for beam chain / snarkification thats on the horizon. - The beam chain would heavily use zkVMs and zkEVMs, which may or may not be in-protocol, and thus we need to make a decision on if / how to include those in PGs eligibility framework. Ideally this discussion should start "in the coming weeks".