### PR TITLE
Add Andrés Jiménez Láinez

### DIFF
--- a/docs/02-membership.md
+++ b/docs/02-membership.md
@@ -67,6 +67,7 @@ The membership is a set of people working within the eligible projects who have 
 | [Davide Crapis](https://github.com/dcrapis/) |0.5| |
 | [Thomas Thiery](https://github.com/soispoke/) |1| [ethresearch](https://ethresear.ch/u/soispoke/summary/) |
 | [Julian Ma](https://github.com/Ma-Julian) |1| |
+| [Andrés Jiménez Láinez](https://github.com/nethoxa/) |1| [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Bhargava Shastry](https://github.com/bshastry/) |1| [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [David Theodore](https://github.com/infosecual/) |1| [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Fredrik Svantes](https://github.com/fredriksvantes/) |1| [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |


### PR DESCRIPTION
Name: Andrés Jiménez Láinez
Team: Protocol Security Research
Start time: 2025-01
Weight: 1

Elegibility:

- Found bugs in EL clients such as Geth [1](https://github.com/ethereum/go-ethereum/pull/31176) [2](https://github.com/ethereum/go-ethereum/pull/31175) and Reth (private)
- Worked on porting [tx-fuzz](https://github.com/MariusVanDerWijden/tx-fuzz) to Rust to have enhanced performance and more mutators (here)(https://github.com/nethoxa/rakoon)
- Worked on the Cantina contest, triaging many issues as well as verifying the fixes
- Contributed to EIPs such as EIP-7702: https://github.com/ethereum/EIPs/pull/9632
- Contributed to some clients like [Nimbus](https://github.com/status-im/nimbus-eth2/pull/7082) and [Reth](https://github.com/paradigmxyz/reth/pull/14623), among others

For more information on his work, you can check his [GitHub profile](https://github.com/nethoxa)