### PR TITLE
Remove @carver and @ogenev

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -45,11 +45,9 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Piotr Dobaczewski](https://github.com/pdobacz) | 1 | [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Apdobacz), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Apdobacz), [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests/pulls?q=author%3Apdobacz), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Apdobacz) |
 | [Radosław Zagórowicz](https://github.com/rodiazet) | 1 | [ethereum/evmc](https://github.com/ethereum/evmc/pulls?q=author%3Arodiazet), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Arodiazet), [ethereum/tests](https://github.com/ethereum/tests/pulls?q=is%3Apr+author%3Arodiazet), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Arodiazet) |
 |**Portal** (6 contributors)| | |
-| [Jason Carver](https://github.com/carver/) | 1 | |
 | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 | [ethereum/trin](https://github.com/ethereum/trin), [ethereum/portal-network-specs](https://github.com/ethereum/portal-network-specs), [ethereum/hive](https://github.com/ethereum/hive) |
 | [Mike Ferris](https://github.com/mrferris/) | 1 | |
 | [Milos Stankovic](https://github.com/morph-dev) | 1 | |
-| [Ognyan Genev](https://github.com/ogenev/) | 1 |[ethereum/trin](https://github.com/ethereum/trin), [ethereum/portal-network-specs](https://github.com/ethereum/portal-network-specs) |
 | [Piper Merriam](https://github.com/ethereum/portal-network-specs) | 1 | |
 | **Networking** (1 contributor) | | |
 | [Pop Chunhapanya](https://github.com/ppopth/) | 1 | |


### PR DESCRIPTION
We are not planning on doing full-time L1 protocol work going forward.