### PR TITLE
Add Rahul

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -61,6 +61,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Mike Neuder](https://github.com/michaelneuder) | 1 | |
 | [Thomas Thiery](https://github.com/soispoke/) | 1 | [ethresear.ch/u/soispoke/summary](https://ethresear.ch/u/soispoke/summary/) |
 | [Toni Wahrstätter](https://github.com/nerolation) | 1 | [nerolation/pglanding-nerolation](https://github.com/nerolation/pglanding-nerolation) |
+| [Rahul](https://github.com/raxhvl) | 1 | [raxhvl/pglanding-raxhvl](https://github.com/raxhvl/pglanding-raxhvl) |
 | **Statelessness** (2 contributors) | | |
 | [Guillaume Ballet](https://github.com/gballet/) | 1 | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Agballet), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=is%3Apr+author%3Agballet), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=is%3Apr+author%3Agballet) |
 | [Ignacio Hagopian](https://github.com/jsign/) | 1 | [crate-crypto/go-ipa](https://github.com/crate-crypto/go-ipa/pulls?q=author%3A%22jsign%22), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%3A%22jsign%22), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=author%3A%22jsign%22) |


### PR DESCRIPTION
Name: Rahul (@raxhvl)
Team: Prototyping
Start time: 2025-01
Weight: 1

Eligibility:
Rahul joined EF earlier this year as a member of the Applied Research Group. He has contributed to various projects, including the [Odometer](https://github.com/eth-act/odometer) client benchmarking suite, a [prototype implementation for Geth](https://www.argchive.dev/post/geth-block-access-list/), and Ethereum [spec tests](https://github.com/ethereum/execution-spec-tests/pulls?q=+is%3Apr+author%3Araxhvl). As part of the newly formed Prototyping team, he continues to experiment with upcoming EIPs, providing insights and other [helpful resources](https://pokebal.raxhvl.com/) to client teams.