### PR TITLE
Proposal: add Snarkification working group

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -11,7 +11,7 @@ Individuals from active working groups produce the membership by opting into Pro
 
 ## WAYFINDING
 - Overview: the exploratory process to surface, describe and validate potential protocol changes
-- 10 Working Groups, 42 contributors
+- 11 Working Groups, 42 contributors
 - Venue: breakout calls
 - Artifacts: Research & POCs
 
@@ -36,14 +36,13 @@ Individuals from active working groups produce the membership by opting into Pro
 | **Data Availability** (2 contributors) | | |
 | [Dmitriy Ryajov](https://github.com/dryajov/) | 0.5 | Codex DAS (IFT) |
 | [Leonardo Bautista-Gomez](https://github.com/leobago/) | 0.5 | [ethresear.ch/u/leobago](https://ethresear.ch/u/leobago/) |
-| **Execution (Gas limit, EVM, delayed, History Expiry)** (7 contributors) | | |
+| **Execution (Gas limit, EVM, delayed, History Expiry)** (6 contributors) | | |
 | [Alex Beregszaszi](https://github.com/axic/) | 0.5 | [ethereum/evmc](https://github.com/ethereum/evmc/pulls?q=author%3Aaxic), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Aaxic), [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo/pulls?q=is%3Apr+author%3Aaxic), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Aaxic) |
 | [Andrei Maiboroda](https://github.com/gumb0/) | 1 | [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Agumb0+), [ethereum/evmc](https://github.com/ethereum/evmc/pulls?q=author%3Agumb0+), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Agumb0+), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Agumb0+) |
 | [Danno Ferrin](https://github.com/shemnon/) | 1 | [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Ashemnon), [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests/pulls?q=author%3Ashemnon), [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ashemnon) |
 | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 | [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Ahugo-dc+), [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests/pulls?q=author%3Ahugo-dc+), [ethereum/tests](https://github.com/ethereum/tests/pulls?q=author%3Ahugo-dc+) |
 | [Paweł Bylica](https://github.com/chfast/) | 1 | [ethereum/evmone](https://github.com/ethereum/evmone/commits?author=chfast) |
 | [Piotr Dobaczewski](https://github.com/pdobacz) | 1 | [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Apdobacz), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Apdobacz), [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests/pulls?q=author%3Apdobacz), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Apdobacz) |
-| [Radosław Zagórowicz](https://github.com/rodiazet) | 1 | [ethereum/evmc](https://github.com/ethereum/evmc/pulls?q=author%3Arodiazet), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Arodiazet), [ethereum/tests](https://github.com/ethereum/tests/pulls?q=is%3Apr+author%3Arodiazet), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Arodiazet) |
 |**Portal** (6 contributors)| | |
 | [Jason Carver](https://github.com/carver/) | 1 | |
 | [Kolby Moroz Liebl](https://github.com/KolbyML) | 1 | [ethereum/trin](https://github.com/ethereum/trin), [ethereum/portal-network-specs](https://github.com/ethereum/portal-network-specs), [ethereum/hive](https://github.com/ethereum/hive) |
@@ -61,13 +60,15 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Mike Neuder](https://github.com/michaelneuder) | 1 | |
 | [Thomas Thiery](https://github.com/soispoke/) | 1 | [ethresear.ch/u/soispoke/summary](https://ethresear.ch/u/soispoke/summary/) |
 | [Toni Wahrstätter](https://github.com/nerolation) | 1 | [nerolation/pglanding-nerolation](https://github.com/nerolation/pglanding-nerolation) |
+| **Snarkification (execution/zkEVM + consensus)** (4 contributors) | | |
+| [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 | |
+| [Ignacio Hagopian](https://github.com/jsign/) | 1 | [crate-crypto/go-ipa](https://github.com/crate-crypto/go-ipa/pulls?q=author%3A%22jsign%22), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%3A%22jsign%22), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=author%3A%22jsign%22) |
+| [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 | |
+| [Radosław Zagórowicz](https://github.com/rodiazet) | 1 | [ethereum/evmc](https://github.com/ethereum/evmc/pulls?q=author%3Arodiazet), [ethereum/evmone](https://github.com/ethereum/evmone/pulls?q=author%3Arodiazet), [ethereum/tests](https://github.com/ethereum/tests/pulls?q=is%3Apr+author%3Arodiazet), [ipsilon/eof](https://github.com/ipsilon/eof/pulls?q=author%3Arodiazet) |
 | **Statelessness** (2 contributors) | | |
 | [Guillaume Ballet](https://github.com/gballet/) | 1 | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Agballet), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=is%3Apr+author%3Agballet), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=is%3Apr+author%3Agballet) |
-| [Ignacio Hagopian](https://github.com/jsign/) | 1 | [crate-crypto/go-ipa](https://github.com/crate-crypto/go-ipa/pulls?q=author%3A%22jsign%22), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%3A%22jsign%22), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=author%3A%22jsign%22) |
-| **Uncategorized** (4 contributors) |  |  |
-| [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 | |
+| **Uncategorized** (2 contributors) |  |  |
 | [Josh Rudolf](https://github.com/jrudolf/) | 1 | |
-| [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 | |
 | [Yoav Weiss](https://github.com/yoavw/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 
 ## GOVERNANCE


### PR DESCRIPTION
## Proposal: add Snarkification working group

**Context:** The potential integration of zero-knowledge proofs (ZKPs) in the Ethereum protocol presents a critical need for focused, collaborative work to ensure their security, interoperability, and responsible development. This includes the advent and proliferation of zkVMs, zkEVMs, and the appearance of "real-time proving" on our horizon.

This proposal outlines the establishment of a "Snarkification" working group within the Protocol Guild to address these evolving needs.

**Mission:** The Snarkification working group will support research, security, standardization, formal verification, and implementation efforts related to the integration of ZKPs into core Ethereum protocols.

This PR also recategorizes existing PG members (Kev, Carl, rodiazet, Ignacio) who have already been engaging in this work.

### Scope and Subcategories
The Snarkification working group will initially focus on two critical subcategories: 

1. Execution (zkEVMs): This subcategory will focus on the use of zkVMs to prove the Ethereum L1 blocks. This includes:
- R&D for design, security, efficiency
- Formal verification
- Standardization efforts for zkEVM architectures and proof formats to promote interoperability

2. Consensus (Lean, Beam): 
- Research into using ZKPs for state transition function (STF) verification (e.g., in projects like the Beam chain)
- Investigation of ZKP applications for signature aggregation and other consensus-critical operations

### Eligibility and Exclusion
Membership within the Snarkification Protocol Guild Working Group is intended to foster collaborative efforts at the protocol level. PG support of beam chain R&D through the Snarkification WG does not currently extend to beam client teams—a separate proposal and framework of requirements would be necessary. Similarly, if there is a need for a spec-specific working group (ie. similar to EELS for the execution layer), this can also be added in the future.

Production zkVM teams are expected to stay outside of the scope of PG for the foreseeable future. The intention is to maintain a focus on foundational protocol-level work that benefits the broader ecosystem, rather than specific product or client development.