### PR TITLE
Add Antoine James

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -242,6 +242,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Scotty Poi](https://github.com/ScottyPoi/) | 1 | [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo/pulls?q=is%3Apr+author%3Ascottypoi+), [ethereumjs/ultralight](https://github.com/ethereumjs/ultralight/pulls?q=is%3Apr+author%3Ascottypoi+) |
 | **Security** (4 contributors) | | |
 | [Andrés Jiménez Láinez](https://github.com/nethoxa/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
+| [Antoine James](https://github.com/0xMushow) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Bhargava Shastry](https://github.com/bshastry/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Tyler Holmes](https://github.com/0xtylerholmes/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |


### PR DESCRIPTION
Name: Antoine James (@0xMushow)
Team: Protocol Security
Start time: 2025-05
Weight: 1

Eligibility:
Talks & Reports
Presented AI x Protocol Security @ [ETHSofia](https://www.ethsofia.com/agenda)
Published the [public disclosure reports](https://github.com/ethereum/public-disclosures/pulls?q=is%3Apr+is%3Aclosed+author%3A0xMushow) for Pectra / Attackathon competitions

Client Contributions (new features / security hardening / bugs)
Reth:[ issues/PRs](https://github.com/paradigmxyz/reth/issues?q=state%3Aclosed%20author%3A0xMushow)
Alloy:[ issues/PRs](https://github.com/alloy-rs/alloy/issues?q=state%3Aclosed%20author%3A0xMushow)
Revm:[ issues/PRs](https://github.com/bluealloy/revm/issues?q=state%3Aclosed%20author%3A0xMushow)
Besu:[ PR #9146](https://github.com/hyperledger/besu/pull/9146)
Geth:[ issue #32458](https://github.com/ethereum/go-ethereum/issues/32458)

EIP Reviews (Fusaka)
5 / 8 EL EIPs
1 / 3 CL EIPs with EL impact (BPO Fork) → notes 
Actively reviewing the contest submissions on Sherlock

Ecosystem Work
Closely following the Gas Limit increase project (Telegram channel)
Gas repricing work with Marius @ Berlin Interop

[Ethereum Code Reviewer](https://review.protocolsecurity.io/?repository_filter=&status_filter=&classification_filter=&user_filter=antoine.james%40ethereum.org&page=1)
Reviewed 8 issues, with 1 more in progress, out of 24 flagged PRs