### PR TITLE
Add Nixo

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -78,6 +78,8 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan) |
 | [Sam Wilson](https://github.com/SamWilsn/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
+| [Nixo](https://github.com/nixorokish/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
+
 | **Consensus Layer Specs + Coordination** (3 contributors) | | |
 | [Alex Stokes](https://github.com/ralexstokes/) | 1 | |
 | [Justin Traglia](https://github.com/jtraglia/) | 1 | [Consensys/teku](https://github.com/Consensys/teku/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia), [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia), [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia) |


### PR DESCRIPTION
Name: Nixo (@nixorokish)
Team: Protocol Support
Start time: 2025-01
Weight: 1

Eligibility: Nixo has joined EF around a year ago and went full time in January. Currently, she is leading Protocol Support team which helps to facilitate processes around the core development. She has been contributing to running ACD, managing EthMag and helping to establish new tools like Forcast and ACDbot. Apart from helping with processes, she is also writing documentation and blogs with updates about core protocol. Her presence in the community goes far longer and the strong connection to validator community helps with our communication and feedback. 

Some of her contributions: 
- [ethereum.org Fusaka page](https://github.com/ethereum/ethereum-org-website/pull/16135)
- [Forkcast content](https://github.com/ethereum/forkcast/pull/1/files)
- [ACD calls](https://github.com/ethereum/pm/issues/1716)
- [Checkpoint updates](https://blog.ethereum.org/2025/07/29/checkpoint-5)
- [PM repo maintanance](https://github.com/ethereum/pm/pull/1308)