### PR TITLE
Add Akash | ECH

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -76,7 +76,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Guru](https://github.com/gurukamath/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Peter Miller](https://github.com/petertdavies/) | 1 | |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan) |
-| [Akash Kshirsagar](https://github.com/akashkshirsagar31) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [X-streams](https://x.com/i/broadcasts/1vAGRDmWBkjxl), [ACD Podcast](https://open.spotify.com/show/7dgxKMkSyy3HWtQW7OfqXA?si=a35e2f3b19ec4c2a)|
+| [Akash Kshirsagar](https://github.com/akashkshirsagar31) | 0.5 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [X-streams](https://x.com/i/broadcasts/1vAGRDmWBkjxl), [ACD Podcast](https://open.spotify.com/show/7dgxKMkSyy3HWtQW7OfqXA?si=a35e2f3b19ec4c2a)|
 | [Sam Wilson](https://github.com/SamWilsn/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
 | **Consensus Layer Specs + Coordination** (3 contributors) | | |

--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -76,6 +76,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Guru](https://github.com/gurukamath/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Peter Miller](https://github.com/petertdavies/) | 1 | |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan) |
+| [Akash Kshirsagar](https://github.com/akashkshirsagar31) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [X-streams](https://x.com/i/broadcasts/1vAGRDmWBkjxl)|
 | [Sam Wilson](https://github.com/SamWilsn/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
 | **Consensus Layer Specs + Coordination** (3 contributors) | | |

--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -76,7 +76,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Guru](https://github.com/gurukamath/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Peter Miller](https://github.com/petertdavies/) | 1 | |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan) |
-| [Akash Kshirsagar](https://github.com/akashkshirsagar31) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [X-streams](https://x.com/i/broadcasts/1vAGRDmWBkjxl)|
+| [Akash Kshirsagar](https://github.com/akashkshirsagar31) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [X-streams](https://x.com/i/broadcasts/1vAGRDmWBkjxl), [ACD Podcast](https://open.spotify.com/show/7dgxKMkSyy3HWtQW7OfqXA?si=a35e2f3b19ec4c2a)|
 | [Sam Wilson](https://github.com/SamWilsn/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Tim Beiko](https://github.com/timbeiko/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
 | **Consensus Layer Specs + Coordination** (3 contributors) | | |


### PR DESCRIPTION
Name: Akash Kshirsagar (@akashkshirsagar31)
Team: ECH
Start time: 2025-01
Weight: 0.5

Eligibility: 
Akash joined ECH over a year ago and has been working with us. Initially, he supported Protocol meeting streaming as a backup, but as the number of breakout rooms and protocol calls has increased, he has taken a much more active role. He now regularly helps organize and stream protocol meetings across EF YouTube and ECH Twitter — a contribution that has significantly improved the reach and visibility of these calls within the wider community.

Most notable contributions for inclusion:
- [ACD Calls Podcast](https://open.spotify.com/show/7dgxKMkSyy3HWtQW7OfqXA?si=a35e2f3b19ec4c2a) 
- Protocol livestreams on [YouTube](https://www.youtube.com/@EthereumProtocol/streams) & [X](https://x.com/i/broadcasts/1vAGRDmWBkjxl)

These reflect sustained dedication, operational reliability and protocol support. I want to propose his nomination.

_Note: Based on initial feedback, this PR has been revised to adjust the weighting, retain only the relevant information, and remove any additional content from consideration._