### PR TITLE
[Nethermind] Add Marcos Maceo (part-time)

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -130,7 +130,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [pinges](https://github.com/pinges/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |
-| **Nethermind** (15 contributors) | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
+| **Nethermind** (17 contributors) | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
 | [Ahmad Bitar](https://github.com/smartprogrammer93) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Asmartprogrammer93+) |
 | [Alexey Osipov](https://github.com/flcl42) | 1 | [NethermindEth/nethermind](https://github.com/flcl42?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls/flcl42) |
 | [Anders Kristiansen](https://github.com/ak88) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aak88) |
@@ -142,6 +142,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 | [NethermindEth/nethermind](https://github.com/LukaszRozmej?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3ALukaszRozmej) |
 | [Marc Harvey-Hill](https://github.com/Marchhill) | 0.5 | [NethermindEth/nethermind](https://github.com/Marchhill?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3AMarchhill) |
 | [Marcin Sobczak](https://github.com/marcindsobczak/) | 1 | [NethermindEth/nethermind](https://github.com/marcindsobczak?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Amarcindsobczak) |
+| [Marcos Maceo](https://github.com/stdevMac/) | 0.5 | [NethermindEth/nethermind](https://github.com/stdevMac?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/commits/master/?author=stdevMac) |
 | [Marek Moraczyński](https://github.com/MarekM25/) | 0.5 | [NethermindEth/nethermind](https://github.com/MarekM25?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3AMarekM25) |
 | [Muhammad Amirul Ashraf](https://github.com/asdacap) | 1 |[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aasdacap) |
 | [Ruben Buniatyan](https://github.com/rubo/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Arubo) |


### PR DESCRIPTION
**Name**: Marcos Maceo
**Project**: Nethermind Client DevOps
**Team**: Nethermind
**Joined**: 01/01/2023
**Summary of their work/eligibility**: Marcos started working in Nethermind before the Merge. He is contributing as DevOps to the Infrastructure requirements for the Nethermind Client, especially in creating workflows for improving testing in the Post-Merge scenario. Other than that Marcos works heavily on tools which are beneficial not only for Nethermind development but for other EL/CL clients as well as for example Sedge which is one click solution for spawning all kind of combinations of clients (one of the major tools used in our QA activities - speeds up work a lot). Additionally Marcos was one of the first contributors to gas-benchamrks repository which is not a most crucial tool for benchmarking of EL clients and deciding on safe gas limit and testing the EIPs in regards of performance criteria's.

**Contributions:**
https://github.com/NethermindEth/nethermind/commits/master/?author=stdevMac
https://github.com/NethermindEth/sedge/pulls?q=is%3Apr+author%3AstdevMac
https://github.com/NethermindEth/gas-benchmarks/commits/main/?author=stdevMac

Other than above ones Marcos contributes a lot to currently private repositories (we plan to make them public) from which other EL/CL clients can benefit a lot like:
1. Tool to spin up all EL and CL clients in Virtualized environment in Linode and sync on all testnets and mainnet.
2. Creating a big library of playbooks in Ansible to easily maintain already created nodes.
3. Infrastructure monitoring dashboard - tool where all spawned VMs with nodes installed can be browsed, edited (without need to interact directly on VM) or removed