### PR TITLE
Add EthCoordinate team + remove Execution/Consensus Coordination

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -216,12 +216,11 @@ Eligible individuals from active teams produce the membership by opting into Pro
 
 | **Team** | **Weight** | **Contributions** |
 |:---|:---|:---|
+| **EthCoordinate - 2 Members** | **2** | |
+| [Marc Garreau](https://github.com/wolovim/) | 1 | [ethereum/pm](https://github.com/ethereum/pm/commits/master/?author=wolovim) |
+| [Nixo](https://github.com/nixorokish/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
 | **Ethereum Cat Herders - 1 Member** | **1** | |
 | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 | [Ethereum Protocol Videos](https://www.youtube.com/@EthereumProtocol), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aclosed+poojaranjan), [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+poojaranjan) |
-| **Consensus Coordination** (1 contributors) | **1** | |
-| [Marc Garreau](https://github.com/wolovim/) | 1 | [ethereum/pm](https://github.com/ethereum/pm/commits/master/?author=wolovim) |****
-| **Execution Coordination** (1 contributors) | **1** | |
-| [Nixo](https://github.com/nixorokish/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
 | **Devops (EF) - 7 Members** | **7** | |
 | [Andrew Davis](https://github.com/savid/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | [Barnabas Busa](https://github.com/barnabasbusa/) | 1 | [ethpandaops](https://github.com/ethpandaops) |


### PR DESCRIPTION
This PR adds the EthCoordinate team, with Nixo and Marc (formerly of "Execution Coordination" and "Consensus Coordination" groups).

Although EthCoordinate is a new team, the members within are not, and we expect them to continue working on the same eligible work within EthCoordinate for the foreseeable future. Thus this PR does not expand eligibility in any way, other than adding a new team to house these existing members. The two members will keep their existing start dates, it wont be reset alongside the creation of this team.

@wolovim or @nixorokish please comment on this PR with a brief overview of EthCoordinate and the work you'll do there.

Other changes within this PR:
- "Execution Coordination" and "Consensus Coordination" groups removed as no one was left